### PR TITLE
fix(error): include constraint in InvalidRetry message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Cross-target test coverage for roundtrip behavior, partial chunks,
   UTF-8 chunk boundaries, retry parsing, comments, and limit
   violations.
+
+### Changed
+
+- `error.to_string` for `InvalidRetry` now states the constraint
+  ("must be a non-negative integer") so the message is actionable
+  without consulting the SSE spec.

--- a/src/ssevents/error.gleam
+++ b/src/ssevents/error.gleam
@@ -22,7 +22,10 @@ pub fn to_string(error: SseError) -> String {
       "event exceeds configured byte limit " <> int.to_string(limit)
     TooManyDataLines(limit) ->
       "event exceeds configured data-line limit " <> int.to_string(limit)
-    InvalidRetry(value) -> "invalid retry field: " <> value
+    InvalidRetry(value) ->
+      "invalid retry value: \""
+      <> value
+      <> "\" (must be a non-negative integer)"
     InvalidField(field) -> "invalid SSE field: " <> field
     UnexpectedEnd -> "unexpected end of input"
     UnsupportedFeature(feature) -> "unsupported feature: " <> feature

--- a/test/ssevents_test.gleam
+++ b/test/ssevents_test.gleam
@@ -401,6 +401,17 @@ pub fn validation_helpers_test() {
   ssevents.validate_retry(-1) |> should.equal(Error(InvalidRetry("-1")))
 }
 
+pub fn error_to_string_invalid_retry_test() {
+  error.to_string(InvalidRetry("nope"))
+  |> should.equal(
+    "invalid retry value: \"nope\" (must be a non-negative integer)",
+  )
+  error.to_string(InvalidRetry("-1"))
+  |> should.equal(
+    "invalid retry value: \"-1\" (must be a non-negative integer)",
+  )
+}
+
 pub fn stream_encode_stream_test() {
   let items = [
     ssevents.comment("a"),


### PR DESCRIPTION
## Summary

Make the rendered `InvalidRetry` error message actionable by including the
constraint, so users do not have to consult the SSE spec to learn that
`retry` must be a non-negative integer.

## Changes

- `src/ssevents/error.gleam`: render `InvalidRetry(value)` as
  `invalid retry value: "<value>" (must be a non-negative integer)`.
- `test/ssevents_test.gleam`: add `error_to_string_invalid_retry_test`
  asserting the new format for both non-numeric and negative inputs.
- `CHANGELOG.md`: note the message change under `Changed`.

## Design Decisions

Took Option 1 from the issue (update the rendered string) rather than
splitting `InvalidRetry` into format/negative variants. The variant
payload stays a `String`, so existing pattern-matching callers (and the
existing tests on the variant value) keep working unchanged. Quoting the
offending value with `"..."` makes empty-string and whitespace inputs
visibly distinct.

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error messages for invalid retry values now explicitly state the constraint requirement (must be a non-negative integer), eliminating the need to consult external specifications.

* **Tests**
  * Added test coverage validating the improved error message formatting for invalid retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->