### PR TITLE
perf(decoder): make ends_with_cr O(1) via tail-byte slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `error.to_string` for `InvalidRetry` now states the constraint
   ("must be a non-negative integer") so the message is actionable
   without consulting the SSE spec.
+
+### Performance
+
+- `decoder.ends_with_cr` is now O(1): it slices the last byte of the
+  buffered chunk instead of reversing the whole buffer just to look at
+  the final byte. Removes a per-`push` cost that scaled with the
+  configured `max_event_bytes`.

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -443,8 +443,9 @@ fn reverse_bytes(input: BitArray, acc: BitArray) -> BitArray {
 }
 
 fn ends_with_cr(bits: BitArray) -> Bool {
-  case reverse_bytes(bits, <<>>) {
-    <<13, _rest:bytes>> -> True
-    _ -> False
+  let size = bit_array.byte_size(bits)
+  case size {
+    0 -> False
+    _ -> bit_array.slice(bits, at: size - 1, take: 1) == Ok(<<13>>)
   }
 }


### PR DESCRIPTION
## Summary

`decoder.ends_with_cr` was reversing the entire buffered chunk on every
`push` that ended mid-CRLF, just to inspect the final byte. Replace that
O(n) walk with an O(1) tail-byte slice so the per-chunk cost stops
scaling with `max_event_bytes`.

## Changes

- `src/ssevents/decoder.gleam`: rewrite `ends_with_cr` to use
  `bit_array.byte_size` + `bit_array.slice` on the last byte, returning
  `False` for the empty-buffer case before slicing.
- `CHANGELOG.md`: add a `Performance` entry under `[Unreleased]`.

## Design Decisions

Kept `reverse_bytes` as-is — its other callers (`apply_field` building
the field name, `find_newline` returning the line content) actually need
the reversed buffer, not just a tail byte. Only `ends_with_cr` was the
mismatch.

`bit_array.slice` returns `Result(BitArray, Nil)`, so we compare against
`Ok(<<13>>)`; failure paths (out-of-range slice, non-byte-aligned input)
fall through to `False`, which is the correct conservative behavior for
this CRLF look-back.

Closes #6