### PR TITLE
refactor(reconnect): use option.or for state field merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   ("must be a non-negative integer") so the message is actionable
   without consulting the SSE spec.
 
+- `reconnect.update` now uses `option.or` for the
+  "prefer-new-fall-back-to-old" merge of `last_event_id` / `retry`,
+  replacing the explicit `case` ladders with a single idiomatic
+  expression.
+
 ### Performance
 
 - `decoder.ends_with_cr` is now O(1): it slices the last byte of the

--- a/src/ssevents/reconnect.gleam
+++ b/src/ssevents/reconnect.gleam
@@ -14,19 +14,11 @@ pub fn new() -> ReconnectState {
 pub fn update(state: ReconnectState, item: event.Item) -> ReconnectState {
   case item {
     event.Comment(_) -> state
-    event.EventItem(ev) -> {
-      let last_event_id = case event.id_of(ev) {
-        Some(id) -> Some(id)
-        None -> state.last_event_id
-      }
-
-      let retry_value = case event.retry_of(ev) {
-        Some(retry) -> Some(retry)
-        None -> state.retry
-      }
-
-      ReconnectState(last_event_id: last_event_id, retry: retry_value)
-    }
+    event.EventItem(ev) ->
+      ReconnectState(
+        last_event_id: option.or(event.id_of(ev), state.last_event_id),
+        retry: option.or(event.retry_of(ev), state.retry),
+      )
   }
 }
 


### PR DESCRIPTION
## Summary

Replace the eight-line `case` ladder in `reconnect.update` with two
`option.or` calls. Same semantics ("prefer the incoming event's value,
fall back to the previous state"), but the intent is now expressed
directly in the type, not reconstructed by the reader.

## Changes

- `src/ssevents/reconnect.gleam`: rewrite the `EventItem` arm of
  `update` to use `option.or` for both `last_event_id` and `retry`, and
  drop the temporary bindings since the constructor call is now small
  enough to inline.
- `CHANGELOG.md`: note the change under `Changed`.

## Design Decisions

`option.or` matches the original semantics exactly:
`Some(_) -> first; None -> second`. No behavior change, no test churn —
existing reconnect tests cover the merge paths and continue to pass.

The `gleam/option` import already brought the module in unqualified, so
no new import was needed for `option.or`.

Closes #7