### PR TITLE
fix(decoder): surface InvalidUtf8 from split_field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   replacing the explicit `case` ladders with a single idiomatic
   expression.
 
+- Decoder field splitting now propagates `Error(InvalidUtf8)` instead of
+  silently substituting an empty string when a `BitArray` → `String`
+  decode fails. The previous `unsafe_text` helper has been removed; the
+  in-practice path through `decode_line` continues to reject invalid
+  UTF-8 upstream, so observable behavior is unchanged for valid inputs.
+
 ### Performance
 
 - `decoder.ends_with_cr` is now O(1): it slices the last byte of the

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -196,7 +196,19 @@ fn apply_field(
   line: String,
   line_byte_size: Int,
 ) -> Result(#(DecodeState, List(event.Item)), SseError) {
-  let #(field, value) = split_field(line)
+  case split_field(line) {
+    Error(error) -> Error(error)
+    Ok(#(field, value)) ->
+      apply_field_parts(state, field, value, line_byte_size)
+  }
+}
+
+fn apply_field_parts(
+  state: DecodeState,
+  field: String,
+  value: String,
+  line_byte_size: Int,
+) -> Result(#(DecodeState, List(event.Item)), SseError) {
   let next_event_bytes = state.event_bytes + line_byte_size
 
   case next_event_bytes > limit.max_event_bytes(state.limits) {
@@ -329,7 +341,7 @@ fn has_meaningful_event_content(state: DecodeState) -> Bool {
   }
 }
 
-fn split_field(line: String) -> #(String, String) {
+fn split_field(line: String) -> Result(#(String, String), SseError) {
   split_field_bytes(bit_array.from_string(line), <<>>, line)
 }
 
@@ -337,16 +349,21 @@ fn split_field_bytes(
   remaining: BitArray,
   field_rev: BitArray,
   fallback: String,
-) -> #(String, String) {
+) -> Result(#(String, String), SseError) {
   case remaining {
-    <<>> -> #(fallback, "")
-    <<58, rest:bytes>> -> #(
-      reverse_bytes(field_rev, <<>>) |> unsafe_text,
-      rest |> unsafe_text |> trim_optional_leading_space,
-    )
+    <<>> -> Ok(#(fallback, ""))
+    <<58, rest:bytes>> ->
+      case bit_array.to_string(reverse_bytes(field_rev, <<>>)) {
+        Error(_) -> Error(InvalidUtf8)
+        Ok(field) ->
+          case bit_array.to_string(rest) {
+            Error(_) -> Error(InvalidUtf8)
+            Ok(value) -> Ok(#(field, trim_optional_leading_space(value)))
+          }
+      }
     <<byte, rest:bytes>> ->
       split_field_bytes(rest, <<byte, field_rev:bits>>, fallback)
-    _ -> #(fallback, "")
+    _ -> Error(InvalidUtf8)
   }
 }
 
@@ -396,13 +413,6 @@ fn decode_line(line: BitArray) -> Result(String, SseError) {
   case bit_array.to_string(line) {
     Ok(text) -> Ok(text)
     Error(_) -> Error(InvalidUtf8)
-  }
-}
-
-fn unsafe_text(bits: BitArray) -> String {
-  case bit_array.to_string(bits) {
-    Ok(text) -> text
-    Error(_) -> ""
   }
 }
 


### PR DESCRIPTION
## Summary

`unsafe_text` silently substituted an empty string whenever
`bit_array.to_string` failed, contradicting the codec's "first decode
error fails the whole operation" semantics. Replace it with a
`Result(#(String, String), SseError)` plumbing through `split_field` /
`split_field_bytes` so any UTF-8 decode failure propagates as
`Error(InvalidUtf8)`.

Implements Option 1 from the issue.

## Changes

- `src/ssevents/decoder.gleam`:
  - `split_field` and `split_field_bytes` now return
    `Result(#(String, String), SseError)`. On `:` separation, both the
    field name and value go through `bit_array.to_string`; either
    failure raises `InvalidUtf8`.
  - `apply_field` now matches on the `Result` and forwards to a new
    `apply_field_parts` helper for the existing field/value handling
    (kept as-is so this PR is purely about error plumbing).
  - Removed the now-unused `unsafe_text` helper.
- `CHANGELOG.md`: note the change under `Changed`.

## Design Decisions

In practice this path is reached only via `decode_line`, which already
rejects invalid UTF-8 upstream — so observable behavior for valid SSE
inputs is unchanged. The fix removes a defensive-but-misleading branch
("on UTF-8 failure, return empty string") that contradicted the rest of
the error model. If `split_field` is ever called from a path that has
not gone through `decode_line`, the error now surfaces honestly instead
of producing a `Field { field: "", value: "..." }` ghost event.

Existing UTF-8 tests
(`decode_bytes_invalid_utf8_in_field_name_test`,
`decode_bytes_invalid_utf8_in_field_value_test`) continue to pass —
those exercise the upstream `decode_line` rejection.

Closes #8