### PR TITLE
docs(readme): document release version sync policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,3 +48,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   buffered chunk instead of reversing the whole buffer just to look at
   the final byte. Removes a per-`push` cost that scaled with the
   configured `max_event_bytes`.
+
+### Documentation
+
+- Document the release process in the README so the `gleam.toml`
+  version, the `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD` rename, and the
+  `vX.Y.Z` tag that drives `release.yml` stay in sync.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,28 @@ mise install
 just ci
 ```
 
+## Release process
+
+The package version lives in [`gleam.toml`](./gleam.toml) and the
+per-version notes live in [`CHANGELOG.md`](./CHANGELOG.md). The two
+must stay in sync.
+
+While developing, add new entries to the `[Unreleased]` section. When
+cutting a release:
+
+1. Bump `version = "X.Y.Z"` in `gleam.toml`.
+2. In `CHANGELOG.md`, rename the `[Unreleased]` heading to
+   `[X.Y.Z] - YYYY-MM-DD` and re-insert a fresh empty `[Unreleased]`
+   section above it.
+3. Land the bump on `main`, then push a `vX.Y.Z` tag.
+
+Pushing the tag triggers
+[`.github/workflows/release.yml`](./.github/workflows/release.yml),
+which runs the full check suite, publishes to Hex, and creates a
+GitHub Release using the matching `[X.Y.Z]` section as its body — so
+if the section is missing or mistyped, the release notes will be
+empty.
+
 ## License
 
 MIT. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Add a "Release process" section to the README so contributors know the
contract between `gleam.toml`, `CHANGELOG.md`, and the `vX.Y.Z` tag that
drives `.github/workflows/release.yml`. Resolves the documentation half
of issue #13; the actual `[Unreleased]` → `[X.Y.Z] - <date>` rename for
the next release happens at release time, per this newly-documented
policy.

## Changes

- `README.md`: new "Release process" section between "Development" and
  "License", spelling out the three-step bump-rename-tag flow and how it
  feeds the release workflow.
- `CHANGELOG.md`: note the addition under `Documentation`.

## Design Decisions

Chose the README over a fresh `CONTRIBUTING.md` because the project is
small, the README is already where contributors land, and there is no
other contributor doc to keep consistent with. The new section directly
references `release.yml`'s `[X.Y.Z]` extraction logic so a future change
to that workflow is easy to keep in sync.

The actual `[Unreleased]` rename for v0.2.0 will happen as part of the
next release PR, not this one — this PR is policy documentation only.

Closes #13