### PR TITLE
refactor(validate): share forbidden-byte check helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   in-practice path through `decode_line` continues to reject invalid
   UTF-8 upstream, so observable behavior is unchanged for valid inputs.
 
+- `validate.validate_event_name` and `validate.validate_id` now share a
+  single `validate_no_forbidden_bytes` helper. No behavior change;
+  removes the duplicated body so adding a new validated field is a
+  one-liner.
+
 ### Performance
 
 - `decoder.ends_with_cr` is now O(1): it slices the last byte of the

--- a/src/ssevents/validate.gleam
+++ b/src/ssevents/validate.gleam
@@ -6,16 +6,20 @@ import ssevents/error.{type SseError, EventTooLarge, InvalidField, InvalidRetry}
 import ssevents/event
 
 pub fn validate_event_name(name: String) -> Result(String, SseError) {
-  case contains_forbidden_text_byte(name) {
-    True -> Error(InvalidField("event"))
-    False -> Ok(name)
-  }
+  validate_no_forbidden_bytes("event", name)
 }
 
 pub fn validate_id(id: String) -> Result(String, SseError) {
-  case contains_forbidden_text_byte(id) {
-    True -> Error(InvalidField("id"))
-    False -> Ok(id)
+  validate_no_forbidden_bytes("id", id)
+}
+
+fn validate_no_forbidden_bytes(
+  field_name: String,
+  value: String,
+) -> Result(String, SseError) {
+  case contains_forbidden_text_byte(value) {
+    True -> Error(InvalidField(field_name))
+    False -> Ok(value)
   }
 }
 


### PR DESCRIPTION
## Summary

`validate_event_name` and `validate_id` were byte-for-byte identical
except for the field name passed to `InvalidField`. Extract the shared
body into a private `validate_no_forbidden_bytes` helper so adding a new
validated field is a one-liner instead of a copy-paste.

## Changes

- `src/ssevents/validate.gleam`: introduce
  `validate_no_forbidden_bytes(field_name, value)` and have both public
  validators delegate to it.
- `CHANGELOG.md`: note the change under `Changed`.

## Design Decisions

Pure refactor — no API change, no behavior change. The existing
`validation_helpers_test` (which exercises both validators with
forbidden bytes) continues to pass and provides the regression net for
this consolidation.

Closes #4