### PR TITLE
refactor(stream): split pull_decoded into focused helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   removes the duplicated body so adding a new validated field is a
   one-liner.
 
+- `stream.pull_decoded` is split into focused private helpers
+  (`step_decoded`, `advance_decoder`, `handle_push`, `handle_finish`,
+  `terminal_error`). Concerns (pending emission, chunk pulling,
+  decoder-result translation, error termination) are now layered
+  instead of interleaved; the original six levels of nested `case`
+  collapse to two.
+
 ### Performance
 
 - `decoder.ends_with_cr` is now O(1): it slices the last byte of the

--- a/src/ssevents/stream.gleam
+++ b/src/ssevents/stream.gleam
@@ -98,86 +98,93 @@ fn pull_decoded(
   pending_rev pending_rev: List(Result(event.Item, SseError)),
   finished finished: Bool,
 ) -> Iterator(Result(event.Item, SseError)) {
-  Iterator(fn() {
-    case pending_rev {
-      [item, ..rest] ->
-        Next(
-          item: item,
-          rest: pull_decoded(
-            decoder: decoder_state,
-            chunks: chunks,
-            pending_rev: rest,
-            finished: finished,
-          ),
-        )
+  Iterator(fn() { step_decoded(decoder_state, chunks, pending_rev, finished) })
+}
 
-      [] ->
-        case finished {
-          True -> Done
-          False ->
-            case next(chunks) {
-              Next(chunk, rest_chunks) ->
-                case decoder.push(decoder_state, chunk) {
-                  Error(error) ->
-                    Next(
-                      item: Error(error),
-                      rest: pull_decoded(
-                        decoder: decoder_state,
-                        chunks: empty(),
-                        pending_rev: [],
-                        finished: True,
-                      ),
-                    )
+fn step_decoded(
+  decoder_state: decoder.DecodeState,
+  chunks: Iterator(BitArray),
+  pending_rev: List(Result(event.Item, SseError)),
+  finished: Bool,
+) -> Step(Result(event.Item, SseError)) {
+  case pending_rev {
+    [item, ..rest] ->
+      Next(
+        item: item,
+        rest: pull_decoded(
+          decoder: decoder_state,
+          chunks: chunks,
+          pending_rev: rest,
+          finished: finished,
+        ),
+      )
+    [] ->
+      case finished {
+        True -> Done
+        False -> advance_decoder(decoder_state, chunks)
+      }
+  }
+}
 
-                  Ok(#(next_decoder, emitted)) ->
-                    case emitted {
-                      [] ->
-                        next(pull_decoded(
-                          decoder: next_decoder,
-                          chunks: rest_chunks,
-                          pending_rev: [],
-                          finished: False,
-                        ))
+fn advance_decoder(
+  decoder_state: decoder.DecodeState,
+  chunks: Iterator(BitArray),
+) -> Step(Result(event.Item, SseError)) {
+  case next(chunks) {
+    Next(chunk, rest_chunks) ->
+      handle_push(
+        decoder.push(decoder_state, chunk),
+        decoder_state,
+        rest_chunks,
+      )
+    Done -> handle_finish(decoder.finish(decoder_state), decoder_state)
+  }
+}
 
-                      _ -> {
-                        let pending = emitted |> list.map(Ok) |> list.reverse
-                        next(pull_decoded(
-                          decoder: next_decoder,
-                          chunks: rest_chunks,
-                          pending_rev: pending,
-                          finished: False,
-                        ))
-                      }
-                    }
-                }
+fn handle_push(
+  result: Result(#(decoder.DecodeState, List(event.Item)), SseError),
+  prev_decoder: decoder.DecodeState,
+  rest_chunks: Iterator(BitArray),
+) -> Step(Result(event.Item, SseError)) {
+  case result {
+    Error(error) -> terminal_error(error, prev_decoder)
+    Ok(#(next_decoder, emitted)) ->
+      step_decoded(
+        next_decoder,
+        rest_chunks,
+        emitted |> list.map(Ok) |> list.reverse,
+        False,
+      )
+  }
+}
 
-              Done ->
-                case decoder.finish(decoder_state) {
-                  Error(error) ->
-                    Next(
-                      item: Error(error),
-                      rest: pull_decoded(
-                        decoder: decoder_state,
-                        chunks: empty(),
-                        pending_rev: [],
-                        finished: True,
-                      ),
-                    )
+fn handle_finish(
+  result: Result(List(event.Item), SseError),
+  decoder_state: decoder.DecodeState,
+) -> Step(Result(event.Item, SseError)) {
+  case result {
+    Error(error) -> terminal_error(error, decoder_state)
+    Ok(emitted) ->
+      step_decoded(
+        decoder_state,
+        empty(),
+        emitted |> list.map(Ok) |> list.reverse,
+        True,
+      )
+  }
+}
 
-                  Ok(emitted) ->
-                    case emitted {
-                      [] -> Done
-                      _ ->
-                        next(pull_decoded(
-                          decoder: decoder_state,
-                          chunks: empty(),
-                          pending_rev: emitted |> list.map(Ok) |> list.reverse,
-                          finished: True,
-                        ))
-                    }
-                }
-            }
-        }
-    }
-  })
+fn terminal_error(
+  error: SseError,
+  decoder_state: decoder.DecodeState,
+) -> Step(Result(event.Item, SseError)) {
+  Next(
+    item: Error(error),
+    rest: pull_decoded(
+      decoder: decoder_state,
+      chunks: empty(),
+      pending_rev: [],
+      finished: True,
+    ),
+  )
 }


### PR DESCRIPTION
## Summary

`stream.pull_decoded` was an ~88-line function reaching six levels of
nested \`case\` expressions, mixing pending-item emission, chunk pulling,
decoder-state updates, and error handling in the same scope. Layer
those concerns into focused private helpers so the happy path reads
top-to-bottom.

## Changes

- \`src/ssevents/stream.gleam\`:
  - \`pull_decoded\` is now a thin wrapper that builds an \`Iterator\` and
    delegates to \`step_decoded\`.
  - \`step_decoded\` handles the pending/finished decision in two cases.
  - \`advance_decoder\` pulls the next chunk and dispatches to
    \`decoder.push\` or \`decoder.finish\`.
  - \`handle_push\` / \`handle_finish\` translate the decoder result into
    the iterator's pending state.
  - \`terminal_error\` materializes a one-shot \`Next(Error(_))\` followed
    by a finished iterator.
- \`CHANGELOG.md\`: note the refactor under \`Changed\`.

## Design Decisions

Pure refactor. Behavior is preserved exactly:

- The reverse-then-emit pattern (\`emitted |> list.map(Ok) |> list.reverse\`)
  is kept; it was correct in the original — popping from a
  \`pending_rev\` stack restores the original order.
- After an error from \`decoder.push\` / \`decoder.finish\`, the iterator
  emits a single \`Error(_)\` then transitions to a finished/empty state,
  matching the original "one shot, then Done" termination.
- Threaded the previous decoder state through \`terminal_error\` so the
  iterator type stays well-formed; it is never inspected on the
  finished branch.

The existing stream tests
(\`stream_decode_stream_test\`, \`stream_decode_stream_with_limits_test\`,
\`stream_decode_stream_error_test\`, \`stream_encode_stream_test\`)
exercise the happy path, the limit-error path, and the
chunk-boundary partial-event path; they continue to pass on both
Erlang and JavaScript targets.

Closes #3