### PR TITLE
feat(facade): document canonical surface and add error_to_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- `ssevents.error_to_string` re-exports `error.to_string` on the facade,
+  so user code that needs to format an `SseError` no longer has to
+  reach into the `ssevents/error` submodule.
 - Initial Gleam project scaffold with package metadata, CI workflows,
   release automation, `just` tasks, mise toolchain pinning, and
   baseline source/test layout.
@@ -66,3 +69,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Document the release process in the README so the `gleam.toml`
   version, the `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD` rename, and the
   `vX.Y.Z` tag that drives `release.yml` stay in sync.
+
+- The `ssevents` facade module is now declared the canonical public
+  surface in its top-of-file doc comment; submodules are an
+  implementation detail and may be reorganized between releases. The
+  README's "Decode a full body" example switches from
+  `ssevents/error.to_string` to the new facade-level
+  `ssevents.error_to_string` to match.

--- a/README.md
+++ b/README.md
@@ -75,12 +75,11 @@ pub fn encode_response_body() -> String {
 
 ```gleam
 import ssevents
-import ssevents/error as sse_error
 
 pub fn decode_example(body: BitArray) {
   case ssevents.decode_bytes(body) {
     Ok(items) -> items
-    Error(error) -> [ssevents.comment(sse_error.to_string(error))]
+    Error(error) -> [ssevents.comment(ssevents.error_to_string(error))]
   }
 }
 ```

--- a/src/ssevents.gleam
+++ b/src/ssevents.gleam
@@ -1,11 +1,19 @@
-//// Top-level convenience facade for the `ssevents` package.
+//// Canonical public surface for the `ssevents` package.
 ////
 //// The focused modules (`ssevents/event`, `ssevents/encoder`,
 //// `ssevents/decoder`, `ssevents/reconnect`, `ssevents/validate`,
 //// `ssevents/limit`, `ssevents/heartbeat`, `ssevents/stream`,
-//// `ssevents/error`) carry the actual implementation. This module
-//// re-exports the most common types and functions so small callers can
-//// stay on a single import.
+//// `ssevents/error`) carry the actual implementation, but they are an
+//// implementation detail: external code should prefer the spellings
+//// re-exported here. This is the surface the README and the published
+//// HexDocs documentation consider authoritative, and it is the surface
+//// that follows semver — the submodule shapes may be reorganized
+//// between releases.
+////
+//// Reach into a submodule directly only when the facade does not yet
+//// expose what you need; in that case, opening an issue so the
+//// missing entry point can be added at this level is preferred to
+//// scattering submodule imports across user code.
 
 import gleam/option.{type Option}
 import ssevents/decoder
@@ -321,4 +329,8 @@ pub fn decode_stream_with_limits(
   limits limits: Limits,
 ) -> Iterator(Result(Item, SseError)) {
   stream.decode_stream_with_limits(chunks, limits: limits)
+}
+
+pub fn error_to_string(error: SseError) -> String {
+  error.to_string(error)
 }

--- a/test/ssevents_test.gleam
+++ b/test/ssevents_test.gleam
@@ -412,6 +412,13 @@ pub fn error_to_string_invalid_retry_test() {
   )
 }
 
+pub fn facade_error_to_string_test() {
+  ssevents.error_to_string(InvalidUtf8)
+  |> should.equal(error.to_string(InvalidUtf8))
+  ssevents.error_to_string(InvalidRetry("nope"))
+  |> should.equal(error.to_string(InvalidRetry("nope")))
+}
+
 pub fn stream_encode_stream_test() {
   let items = [
     ssevents.comment("a"),


### PR DESCRIPTION
## Summary

Take Option 2 from the issue: keep the `ssevents` facade complete and
declare it the canonical public surface in its module-level doc
comment. Submodules become an implementation detail. Also fill the one
gap that pushed the README to import `ssevents/error` directly:
re-export `error.to_string` as `ssevents.error_to_string`.

## Changes

- `src/ssevents.gleam`:
  - Rewrite the top-of-file doc comment to state the facade is the
    canonical public surface, that submodules are an implementation
    detail, and that follow-on work to add a missing facade entry
    point is preferred to scattering submodule imports across user
    code.
  - Add `pub fn error_to_string(error)` delegating to
    `error.to_string`.
- `README.md`: switch the "Decode a full body" example from
  `ssevents/error as sse_error` + `sse_error.to_string` to the new
  `ssevents.error_to_string`, removing the only remaining submodule
  import in user-facing examples.
- `test/ssevents_test.gleam`: add `facade_error_to_string_test`
  asserting the facade and the submodule produce identical output for
  representative variants (`InvalidUtf8`, `InvalidRetry`).
- `CHANGELOG.md`: note the addition under `Added` and the policy under
  `Documentation`.

## Design Decisions

Picked Option 2 over Option 1 because the existing README is already
written in the top-level-only style, and slimming the facade would
break those snippets and force users to spread imports across modules.
Documenting the facade as canonical resolves the "two ways to spell
the same call" confusion without breaking compatibility.

Named the new function `error_to_string` (not `to_string`) to follow
the facade's existing namespace-by-prefix convention
(`validate_*`, `update_reconnect`, `iterator_*`) and to leave room for
other `to_string`-shaped helpers without collision.

Closes #5