### PR TITLE
refactor(facade): rename event_name to name_of for accessor consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   instead of interleaved; the original six levels of nested `case`
   collapse to two.
 
+- **Breaking:** the facade-level `Event` accessor is renamed
+  `ssevents.event_name` → `ssevents.name_of` so the four event
+  accessors share the `*_of` suffix already used by `data_of`,
+  `id_of`, and `retry_of`. Callers that read the event name through
+  the facade need to update the call site.
+
 ### Performance
 
 - `decoder.ends_with_cr` is now O(1): it slices the last byte of the

--- a/src/ssevents.gleam
+++ b/src/ssevents.gleam
@@ -86,7 +86,7 @@ pub fn named(name: String, data: String) -> Event {
   event.named(name, data)
 }
 
-pub fn event_name(event: Event) -> Option(String) {
+pub fn name_of(event: Event) -> Option(String) {
   event.name_of(event)
 }
 

--- a/test/ssevents_test.gleam
+++ b/test/ssevents_test.gleam
@@ -29,7 +29,7 @@ pub fn event_builder_accessors_test() {
     |> ssevents.id("job-1")
     |> ssevents.retry(5000)
 
-  ssevents.event_name(event) |> should.equal(Some("job.update"))
+  ssevents.name_of(event) |> should.equal(Some("job.update"))
   ssevents.data_of(event) |> should.equal("payload")
   ssevents.id_of(event) |> should.equal(Some("job-1"))
   ssevents.retry_of(event) |> should.equal(Some(5000))
@@ -136,7 +136,7 @@ pub fn decode_simple_event_test() {
   let assert Ok([EventItem(event)]) =
     ssevents.decode("event: ping\ndata: hello\nid: 1\nretry: 1000\n\n")
 
-  ssevents.event_name(event) |> should.equal(Some("ping"))
+  ssevents.name_of(event) |> should.equal(Some("ping"))
   ssevents.data_of(event) |> should.equal("hello")
   ssevents.id_of(event) |> should.equal(Some("1"))
   ssevents.retry_of(event) |> should.equal(Some(1000))
@@ -176,14 +176,14 @@ pub fn decode_unknown_fields_are_ignored_test() {
     ssevents.decode("foo: bar\ndata: ok\nanother\n\n")
 
   ssevents.data_of(event) |> should.equal("ok")
-  ssevents.event_name(event) |> should.equal(None)
+  ssevents.name_of(event) |> should.equal(None)
 }
 
 pub fn decode_crlf_test() {
   let assert Ok([EventItem(event)]) =
     ssevents.decode("event: ping\r\ndata: hello\r\n\r\n")
 
-  ssevents.event_name(event) |> should.equal(Some("ping"))
+  ssevents.name_of(event) |> should.equal(Some("ping"))
   ssevents.data_of(event) |> should.equal("hello")
 }
 


### PR DESCRIPTION
## Summary

Take Option A from the issue: keep `name_of` / `id_of` / `data_of` /
`retry_of` as the canonical accessor naming and align the facade with
it. Today only `ssevents.event_name` was the odd one out (the other
three already used the `*_of` suffix). Renaming it to
`ssevents.name_of` removes the convention split between layers and
makes the four accessors visually grouped.

This is a public API rename, so it is intentionally landed before
v0.2.0 to avoid a post-release breaking change.

## Changes

- `src/ssevents.gleam`: rename `event_name(event)` → `name_of(event)`,
  still delegating to `event.name_of`.
- `test/ssevents_test.gleam`: update the four call sites to the new
  spelling.
- `CHANGELOG.md`: note this as a `Breaking` entry under `Changed`.

## Design Decisions

Picked Option A (rename facade) over Option B (rename internals) for
two reasons:

1. The internal `*_of` naming is already consistent across all four
   accessors and across the `event` submodule — touching it would
   churn three other names plus their callers.
2. The facade only has the one offender, so the smaller change ships
   the same end state.

`name_of` does not say "event" in the name, but it takes an `Event`
parameter, so the type system already constrains usage. The
internal/facade names now match exactly, removing the "two ways to
spell the same call" newcomer confusion the issue called out.

The README does not use the getter (`event_name`) — only the setter
(`event(event, name)`) — so no README change is needed. The setter
naming is intentionally distinct from the getter (it is a builder, not
an accessor) and is already consistent.

Closes #10