### PR TITLE
refactor(decoder): share validated-field handler in apply_field_parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `id_of`, and `retry_of`. Callers that read the event name through
   the facade need to update the call site.
 
+- `decoder.apply_field_parts` no longer hand-rolls four near-identical
+  branches for `data` / `event` / `id` / `retry`. The three
+  validated-then-set fields share a new `apply_validated_field` helper
+  that takes the validation `Result` plus a setter closure; `data`
+  keeps its dedicated `apply_data_field` because it has its own
+  `TooManyDataLines` limit check. Adding a new validated field now
+  costs one entry in the `case`, not a copy-pasted block.
+
 ### Performance
 
 - `decoder.ends_with_cr` is now O(1): it slices the last byte of the

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -215,73 +215,65 @@ fn apply_field_parts(
     True -> Error(EventTooLarge(limit.max_event_bytes(state.limits)))
     False ->
       case field {
-        "data" ->
-          case state.data_line_count + 1 > limit.max_data_lines(state.limits) {
-            True -> Error(TooManyDataLines(limit.max_data_lines(state.limits)))
-            False ->
-              Ok(
-                #(
-                  DecodeState(
-                    ..state,
-                    data_lines_rev: [value, ..state.data_lines_rev],
-                    data_line_count: state.data_line_count + 1,
-                    event_bytes: next_event_bytes,
-                  ),
-                  [],
-                ),
-              )
-          }
-
+        "data" -> apply_data_field(state, value, next_event_bytes)
         "event" ->
-          case validate.validate_event_name(value) {
-            Error(error) -> Error(error)
-            Ok(valid_name) ->
-              Ok(
-                #(
-                  DecodeState(
-                    ..state,
-                    event_name: Some(valid_name),
-                    event_bytes: next_event_bytes,
-                  ),
-                  [],
-                ),
-              )
-          }
-
+          apply_validated_field(
+            state,
+            validate.validate_event_name(value),
+            next_event_bytes,
+            fn(s, v) { DecodeState(..s, event_name: Some(v)) },
+          )
         "id" ->
-          case validate.validate_id(value) {
-            Error(error) -> Error(error)
-            Ok(valid_id) ->
-              Ok(
-                #(
-                  DecodeState(
-                    ..state,
-                    id: Some(valid_id),
-                    event_bytes: next_event_bytes,
-                  ),
-                  [],
-                ),
-              )
-          }
-
+          apply_validated_field(
+            state,
+            validate.validate_id(value),
+            next_event_bytes,
+            fn(s, v) { DecodeState(..s, id: Some(v)) },
+          )
         "retry" ->
-          case parse_retry(value, state.limits) {
-            Error(error) -> Error(error)
-            Ok(retry_value) ->
-              Ok(
-                #(
-                  DecodeState(
-                    ..state,
-                    retry: Some(retry_value),
-                    event_bytes: next_event_bytes,
-                  ),
-                  [],
-                ),
-              )
-          }
-
+          apply_validated_field(
+            state,
+            parse_retry(value, state.limits),
+            next_event_bytes,
+            fn(s, v) { DecodeState(..s, retry: Some(v)) },
+          )
         _ -> Ok(#(DecodeState(..state, event_bytes: next_event_bytes), []))
       }
+  }
+}
+
+fn apply_data_field(
+  state: DecodeState,
+  value: String,
+  next_event_bytes: Int,
+) -> Result(#(DecodeState, List(event.Item)), SseError) {
+  case state.data_line_count + 1 > limit.max_data_lines(state.limits) {
+    True -> Error(TooManyDataLines(limit.max_data_lines(state.limits)))
+    False ->
+      Ok(
+        #(
+          DecodeState(
+            ..state,
+            data_lines_rev: [value, ..state.data_lines_rev],
+            data_line_count: state.data_line_count + 1,
+            event_bytes: next_event_bytes,
+          ),
+          [],
+        ),
+      )
+  }
+}
+
+fn apply_validated_field(
+  state: DecodeState,
+  validated: Result(a, SseError),
+  next_event_bytes: Int,
+  set: fn(DecodeState, a) -> DecodeState,
+) -> Result(#(DecodeState, List(event.Item)), SseError) {
+  case validated {
+    Error(error) -> Error(error)
+    Ok(value) ->
+      Ok(#(set(DecodeState(..state, event_bytes: next_event_bytes), value), []))
   }
 }
 


### PR DESCRIPTION
## Summary

`apply_field_parts` had four near-identical branches for `data`,
`event`, `id`, `retry` — each one validated the value, built an
updated `DecodeState`, and returned the same `Ok(#(state, []))` shape.
Replace the three validated-then-set branches with a single
`apply_validated_field` helper, and pull the data-line case into its
own `apply_data_field` helper for symmetry.

## Changes

- `src/ssevents/decoder.gleam`:
  - `apply_field_parts` becomes a small dispatch table — each case is
    a setter closure plus the validator's `Result`.
  - New private `apply_validated_field(state, validated, event_bytes,
    set)` handles the `Error` / `Ok` shape once.
  - New private `apply_data_field(state, value, next_event_bytes)`
    handles the `data` case (kept separate because it has its own
    `TooManyDataLines` limit check that the others do not).
- `CHANGELOG.md`: note the refactor under `Changed`.

## Design Decisions

`data` does not share the helper because its limit check
(`max_data_lines`) sits between "validation" and "set", and folding
that into the generic helper would require either an extra closure
parameter or a `Result` to carry both the validated value and a
secondary error. Keeping it as its own one-purpose helper kept the
generic helper genuinely generic — three callers, no special cases.

The setter closures are inlined at the call site so each field's
update is self-contained and grep-able. Adding a future validated
field now requires one new `case` arm + the field's validator + a
one-line setter closure.

Pure refactor — behavior preserved exactly. The decoder test suite
(retry parsing, event name validation, id validation, data line
limit, event byte limit, unknown-field ignore) continues to pass on
both Erlang and JavaScript targets.

Closes #2