### PR TITLE
fix(decoder): strip leading UTF-8 BOM (U+FEFF) per WHATWG SSE §9.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Decoder: leading UTF-8 BOM (U+FEFF) is now stripped** before
+  parsing, per WHATWG SSE §9.2.5. Previously a stream that began
+  with the three-byte BOM (`EF BB BF`) — common from UTF-8 emitters
+  like `iconv -t UTF-8` and hand-edited fixtures — failed to parse
+  the first event. The check runs once per `DecodeState` (tracked
+  via a new `bom_handled` flag) and correctly handles the
+  incremental decoder when the BOM is split across `push` calls. (#35)
+
 ## [0.2.0] - 2026-04-29
 
 ### Added

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -31,6 +31,12 @@ pub opaque type DecodeState {
     retry: Option(Int),
     event_bytes: Int,
     limits: limit.Limits,
+    /// True once the leading-BOM check has run for this stream.
+    /// WHATWG SSE §9.2.5 requires a single U+FEFF at the start of
+    /// the stream to be discarded; once we've either stripped it
+    /// or established the stream doesn't start with one, this
+    /// flag is set so the check doesn't repeat on later pushes.
+    bom_handled: Bool,
   )
 }
 
@@ -77,6 +83,7 @@ pub fn new_decoder_with_limits(limits: limit.Limits) -> DecodeState {
     retry: None,
     event_bytes: 0,
     limits: limits,
+    bom_handled: False,
   )
 }
 
@@ -85,8 +92,30 @@ pub fn push(
   chunk: BitArray,
 ) -> Result(#(DecodeState, List(event.Item)), SseError) {
   let combined = bit_array.append(to: state.buffer, suffix: chunk)
-  let state = DecodeState(..state, buffer: combined)
+  let state = DecodeState(..state, buffer: combined) |> maybe_strip_bom
   process_lines(state, [])
+}
+
+/// WHATWG SSE §9.2.5: discard a leading U+FEFF BYTE ORDER MARK at the
+/// very start of the stream.
+///
+/// `state.bom_handled` is set once we've either stripped the BOM or
+/// established the stream doesn't start with one. While the buffer
+/// holds only a 1- or 2-byte prefix of the BOM (`EF` or `EF BB`), we
+/// hold off on deciding so the check stays correct even when the BOM
+/// is split across two `push` calls.
+fn maybe_strip_bom(state: DecodeState) -> DecodeState {
+  case state.bom_handled, state.buffer {
+    True, _ -> state
+    False, <<0xEF, 0xBB, 0xBF, rest:bytes>> ->
+      DecodeState(..state, buffer: rest, bom_handled: True)
+    // Buffer holds a 1- or 2-byte prefix of the BOM; wait for more.
+    False, <<0xEF, 0xBB>> -> state
+    False, <<0xEF>> -> state
+    False, <<>> -> state
+    // Anything else: not a BOM-prefixed stream, never check again.
+    False, _ -> DecodeState(..state, bom_handled: True)
+  }
 }
 
 pub fn finish(state: DecodeState) -> Result(List(event.Item), SseError) {

--- a/test/ssevents/decoder_test.gleam
+++ b/test/ssevents/decoder_test.gleam
@@ -219,6 +219,52 @@ pub fn incremental_push_handles_crlf_with_one_byte_chunks_test() {
   trailing |> should.equal([])
 }
 
+// WHATWG SSE §9.2.5: a leading U+FEFF BOM at the start of the stream
+// must be stripped before parsing. The BOM is the UTF-8 byte sequence
+// EF BB BF.
+
+pub fn decode_bytes_strips_leading_bom_test() {
+  let body = <<0xEF, 0xBB, 0xBF, "data: hello\n\n":utf8>>
+  let assert Ok(items) = ssevents.decode_bytes(body)
+  items |> should.equal([EventItem(ssevents.new("hello"))])
+}
+
+pub fn decode_bytes_only_strips_one_bom_test() {
+  // A second BOM in the *body* (not at the start) is not part of the
+  // §9.2.5 rule and should pass through as data bytes — but `data:`
+  // lines are decoded as UTF-8 strings, so a stray BOM mid-data
+  // becomes a U+FEFF character in the data value.
+  let body = <<0xEF, 0xBB, 0xBF, "data: ":utf8, 0xEF, 0xBB, 0xBF, "x\n\n":utf8>>
+  let assert Ok([EventItem(event)]) = ssevents.decode_bytes(body)
+  ssevents.data_of(event) |> should.equal("\u{FEFF}x")
+}
+
+pub fn decode_bytes_no_bom_unchanged_test() {
+  // Non-BOM bytes that happen to start with 0xEF (e.g., a UTF-8
+  // multi-byte char like `ï` = C3 AF, not 0xEF) must not trigger
+  // BOM stripping. Use a clean ASCII case to confirm baseline.
+  let body = <<"data: hello\n\n":utf8>>
+  let assert Ok(items) = ssevents.decode_bytes(body)
+  items |> should.equal([EventItem(ssevents.new("hello"))])
+}
+
+pub fn incremental_push_strips_bom_split_across_chunks_test() {
+  // Push the BOM bytes one at a time, then the rest. The decoder
+  // should still strip the full BOM and emit one event.
+  let state = ssevents.new_decoder()
+  let assert Ok(#(state, items1)) = ssevents.push(state, <<0xEF>>)
+  items1 |> should.equal([])
+  let assert Ok(#(state, items2)) = ssevents.push(state, <<0xBB>>)
+  items2 |> should.equal([])
+  let assert Ok(#(state, items3)) = ssevents.push(state, <<0xBF>>)
+  items3 |> should.equal([])
+  let assert Ok(#(state, items4)) =
+    ssevents.push(state, <<"data: hello\n\n":utf8>>)
+  items4 |> should.equal([EventItem(ssevents.new("hello"))])
+  let assert Ok(trailing) = ssevents.finish(state)
+  trailing |> should.equal([])
+}
+
 fn bytes_to_single_byte_chunks(bits: BitArray) -> List(BitArray) {
   bytes_to_single_byte_chunks_loop(bits, [])
 }

--- a/test/ssevents/decoder_test.gleam
+++ b/test/ssevents/decoder_test.gleam
@@ -240,9 +240,8 @@ pub fn decode_bytes_only_strips_one_bom_test() {
 }
 
 pub fn decode_bytes_no_bom_unchanged_test() {
-  // Non-BOM bytes that happen to start with 0xEF (e.g., a UTF-8
-  // multi-byte char like `ï` = C3 AF, not 0xEF) must not trigger
-  // BOM stripping. Use a clean ASCII case to confirm baseline.
+  // Baseline: a stream that does not start with the BOM byte
+  // sequence (`EF BB BF`) decodes the same way it always did.
   let body = <<"data: hello\n\n":utf8>>
   let assert Ok(items) = ssevents.decode_bytes(body)
   items |> should.equal([EventItem(ssevents.new("hello"))])


### PR DESCRIPTION
## Summary

Strip the leading UTF-8 BOM (U+FEFF) at the start of an SSE stream before parsing, per WHATWG SSE §9.2.5. The fix works for both the one-shot `decode_bytes` and the incremental `push` flow, including when the three BOM bytes are split across `push` calls.

## Changes

- `src/ssevents/decoder.gleam`:
  - new `bom_handled: Bool` field on `DecodeState`, defaulting to `False`
  - new private `maybe_strip_bom` helper called at the top of `push` that strips a leading `EF BB BF` sequence and sets the flag
  - holds off on deciding when the buffer holds only a 1- or 2-byte prefix of the BOM (so a BOM split across two `push` calls is still recognised correctly)
- `test/ssevents/decoder_test.gleam`: 4 new tests covering BOM at the start, no-BOM baseline, a stray BOM mid-data preserved as a U+FEFF character in the data value, and the BOM-split-across-chunks incremental case
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]`

## Design Decisions

The check runs once per `DecodeState`, gated by `bom_handled`. We deliberately don't decode the buffer through `bit_array.to_string` to detect the BOM — bytes are inspected raw, so a partial BOM doesn't trigger an `InvalidUtf8` on a subsequent `push`. The empty-buffer branch returns the state unchanged so a `push` with an empty chunk stays a no-op.

Closes #35


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSE decoder to properly handle and remove leading UTF-8 BOM, preventing the first event from failing to parse.
  * Enhanced support for incremental decoding when BOM arrives fragmented across multiple data chunks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->