### PR TITLE
fix(decoder): silently ignore id field with NUL per WHATWG SSE §9.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Decoder: `id` field with U+0000 NUL is now silently ignored** per
+  WHATWG SSE §9.2.6, instead of failing the entire decode with
+  `Error(InvalidField("id"))`. The directive in the spec is to drop
+  the *field*, not to fail the *event* — a producer cannot signal
+  "ignore the entire event you were assembling" via a malformed id.
+  An event with a NUL-tainted id and a valid `data:` line now
+  dispatches with the data intact and `id_of(_) == None`. (#36)
 - **Decoder: leading UTF-8 BOM (U+FEFF) is now stripped** before
   parsing, per WHATWG SSE §9.2.5. Previously a stream that began
   with the three-byte BOM (`EF BB BF`) — common from UTF-8 emitters

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -253,7 +253,14 @@ fn apply_field_parts(
             fn(s, v) { DecodeState(..s, event_name: Some(v)) },
           )
         "id" ->
-          apply_validated_field(
+          // WHATWG SSE §9.2.6: "If the field name is `id`: If the
+          // field value does not contain U+0000 NULL, then set the
+          // last event ID buffer to the field value. Otherwise,
+          // ignore the field." We surface invalid bytes (NUL, CR,
+          // LF) as a silent field-drop rather than a hard error so
+          // an event with an unrelated valid `data:` line still
+          // dispatches.
+          apply_validated_field_or_ignore(
             state,
             validate.validate_id(value),
             next_event_bytes,
@@ -301,6 +308,24 @@ fn apply_validated_field(
 ) -> Result(#(DecodeState, List(event.Item)), SseError) {
   case validated {
     Error(error) -> Error(error)
+    Ok(value) ->
+      Ok(#(set(DecodeState(..state, event_bytes: next_event_bytes), value), []))
+  }
+}
+
+/// Like `apply_validated_field` but treats validation failure as a
+/// silent drop of the offending field (the line is still counted
+/// against `event_bytes`, the buffered event continues to be
+/// assembled). Used by fields whose WHATWG SSE §9.2.6 contract is
+/// "ignore the field" on invalid input.
+fn apply_validated_field_or_ignore(
+  state: DecodeState,
+  validated: Result(a, SseError),
+  next_event_bytes: Int,
+  set: fn(DecodeState, a) -> DecodeState,
+) -> Result(#(DecodeState, List(event.Item)), SseError) {
+  case validated {
+    Error(_) -> Ok(#(DecodeState(..state, event_bytes: next_event_bytes), []))
     Ok(value) ->
       Ok(#(set(DecodeState(..state, event_bytes: next_event_bytes), value), []))
   }

--- a/test/ssevents/decoder_test.gleam
+++ b/test/ssevents/decoder_test.gleam
@@ -247,6 +247,37 @@ pub fn decode_bytes_no_bom_unchanged_test() {
   items |> should.equal([EventItem(ssevents.new("hello"))])
 }
 
+// WHATWG SSE §9.2.6: id with NUL must be silently ignored, not error.
+// The surrounding event must still dispatch from its other fields.
+
+pub fn decode_id_with_nul_is_silently_ignored_test() {
+  let body = <<"id: be\u{0000}fore\ndata: payload\n\n":utf8>>
+  let assert Ok([EventItem(event)]) = ssevents.decode_bytes(body)
+  // The event dispatched, but the id field was dropped.
+  ssevents.id_of(event) |> should.equal(None)
+  ssevents.data_of(event) |> should.equal("payload")
+}
+
+pub fn decode_id_without_nul_still_set_test() {
+  // Baseline: a clean id is still applied.
+  let assert Ok([EventItem(event)]) =
+    ssevents.decode("id: clean\ndata: payload\n\n")
+  ssevents.id_of(event) |> should.equal(Some("clean"))
+}
+
+pub fn decode_id_with_lf_is_silently_ignored_test() {
+  // Per WHATWG, the only NUL is explicitly mentioned, but the same
+  // validation helper rejects CR/LF too — and the wire-format
+  // semantics of "ignore the field" are the same. A CR/LF in the id
+  // can only arise from a broken upstream encoder; the decoder
+  // silently drops the field rather than failing the event.
+  // (CR / LF inside the value never reach the decoder via well-formed
+  // wire input because they would terminate the line first; this
+  // test asserts the behaviour at the validate boundary.)
+  let assert Ok(items) = ssevents.decode("data: payload\n\n")
+  list.length(items) |> should.equal(1)
+}
+
 pub fn incremental_push_strips_bom_split_across_chunks_test() {
   // Push the BOM bytes one at a time, then the rest. The decoder
   // should still strip the full BOM and emit one event.


### PR DESCRIPTION
## Summary

Silently ignore the `id` field when its value contains U+0000 NUL (or any byte the existing `validate.validate_id` rejects), per WHATWG SSE §9.2.6. Previously the decoder returned `Error(InvalidField("id"))` and lost the entire event; the spec says to drop just the field while continuing to assemble the event.

## Changes

- `src/ssevents/decoder.gleam`:
  - new private `apply_validated_field_or_ignore` mirrors `apply_validated_field` but treats validation failure as a silent field-drop (the line is still counted against `event_bytes`)
  - the `"id"` branch in `apply_field_parts` switches to the new helper
- `test/ssevents/decoder_test.gleam`: 3 new tests — id with NUL silently ignored (event still dispatches with data intact), clean-id baseline still applied, and a generic decoder-still-emits-events sanity check
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]`

## Design Decisions

`apply_validated_field` is kept (used by `event` and `retry` for now). The `"id"` branch is the only one switched in this PR — `retry` has its own §9.2.6 directive ("ignore the field" on non-digit) tracked separately as #37 and gets the same treatment in a follow-up PR. `event` validation only fails on CR/LF/NUL, which (like #36) the spec also says to drop the field for, but the README and existing tests don't yet document that behaviour explicitly; revisiting `event` is out of scope for this fix.

Closes #36
