### PR TITLE
fix(decoder): silently ignore non-ASCII-digit retry values per WHATWG SSE §9.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Decoder: `retry` field that isn't all ASCII digits is now silently
+  ignored** per WHATWG SSE §9.2.6, instead of failing the whole decode
+  with `Error(InvalidRetry(value))`. Affects `12.5` (decimal),
+  `-100` (negative — `-` isn't an ASCII digit), the empty string, and
+  any value containing letters or punctuation. The surrounding event
+  still dispatches from its other fields. The custom `max_retry_value`
+  safety bound (a per-decoder DoS limit, not a spec rule) continues
+  to be a hard `Error(InvalidRetry(value))`. **Behavioural change**:
+  `decode("retry: nope\n\n")` previously returned
+  `Error(InvalidRetry("nope"))`; it now returns `Ok([])` (event has
+  no `data:` so nothing to dispatch). (#37)
 - **Decoder: `id` field with U+0000 NUL is now silently ignored** per
   WHATWG SSE §9.2.6, instead of failing the entire decode with
   `Error(InvalidField("id"))`. The directive in the spec is to drop

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -267,12 +267,24 @@ fn apply_field_parts(
             fn(s, v) { DecodeState(..s, id: Some(v)) },
           )
         "retry" ->
-          apply_validated_field(
-            state,
-            parse_retry(value, state.limits),
-            next_event_bytes,
-            fn(s, v) { DecodeState(..s, retry: Some(v)) },
-          )
+          // WHATWG SSE §9.2.6: "If the field value consists of only
+          // ASCII digits ... Otherwise, ignore the field." Drop the
+          // field silently when the value isn't all ASCII digits
+          // (negative `-100`, decimal `12.5`, empty, etc.). Values
+          // that *are* all digits but exceed `max_retry_value` are
+          // still surfaced as `Error(InvalidRetry(_))` because that
+          // limit is a per-decoder safety bound, not a spec rule.
+          case is_ascii_digit_string(value) {
+            False ->
+              Ok(#(DecodeState(..state, event_bytes: next_event_bytes), []))
+            True ->
+              apply_validated_field(
+                state,
+                parse_retry(value, state.limits),
+                next_event_bytes,
+                fn(s, v) { DecodeState(..s, retry: Some(v)) },
+              )
+          }
         _ -> Ok(#(DecodeState(..state, event_bytes: next_event_bytes), []))
       }
   }

--- a/test/ssevents/decoder_test.gleam
+++ b/test/ssevents/decoder_test.gleam
@@ -80,8 +80,12 @@ pub fn decode_empty_data_event_test() {
 }
 
 pub fn decode_invalid_retry_test() {
+  // WHATWG SSE §9.2.6: a `retry:` value that isn't all ASCII digits
+  // is silently ignored. The only field on this event is the bad
+  // retry, so the event has no `data:` and is not dispatched at all
+  // — an empty list is the expected result.
   ssevents.decode("retry: nope\n\n")
-  |> should.equal(Error(InvalidRetry("nope")))
+  |> should.equal(Ok([]))
 }
 
 pub fn decode_bytes_invalid_utf8_in_field_name_test() {
@@ -245,6 +249,57 @@ pub fn decode_bytes_no_bom_unchanged_test() {
   let body = <<"data: hello\n\n":utf8>>
   let assert Ok(items) = ssevents.decode_bytes(body)
   items |> should.equal([EventItem(ssevents.new("hello"))])
+}
+
+// WHATWG SSE §9.2.6: retry with non-ASCII-digit value must be
+// silently ignored, not error. The surrounding event still dispatches.
+
+pub fn decode_retry_decimal_is_silently_ignored_test() {
+  let body = <<"retry: 12.5\ndata: ping\n\n":utf8>>
+  let assert Ok([EventItem(event)]) = ssevents.decode_bytes(body)
+  ssevents.retry_of(event) |> should.equal(None)
+  ssevents.data_of(event) |> should.equal("ping")
+}
+
+pub fn decode_retry_negative_is_silently_ignored_test() {
+  // Per WHATWG, "ASCII digits" excludes the `-` character — negative
+  // values must be ignored.
+  let body = <<"retry: -100\ndata: ping\n\n":utf8>>
+  let assert Ok([EventItem(event)]) = ssevents.decode_bytes(body)
+  ssevents.retry_of(event) |> should.equal(None)
+  ssevents.data_of(event) |> should.equal("ping")
+}
+
+pub fn decode_retry_empty_is_silently_ignored_test() {
+  // Zero ASCII digits is not "only ASCII digits" — ignore.
+  let body = <<"retry: \ndata: ping\n\n":utf8>>
+  let assert Ok([EventItem(event)]) = ssevents.decode_bytes(body)
+  ssevents.retry_of(event) |> should.equal(None)
+  ssevents.data_of(event) |> should.equal("ping")
+}
+
+pub fn decode_retry_alpha_is_silently_ignored_test() {
+  let body = <<"retry: abc\ndata: ping\n\n":utf8>>
+  let assert Ok([EventItem(event)]) = ssevents.decode_bytes(body)
+  ssevents.retry_of(event) |> should.equal(None)
+  ssevents.data_of(event) |> should.equal("ping")
+}
+
+pub fn decode_retry_within_limit_still_set_test() {
+  // Baseline: an all-digits value within the safety limit is still
+  // applied.
+  let assert Ok([EventItem(event)]) =
+    ssevents.decode("retry: 1500\ndata: payload\n\n")
+  ssevents.retry_of(event) |> should.equal(Some(1500))
+}
+
+pub fn decode_retry_above_limit_still_errors_test() {
+  // The `max_retry_value` safety bound is a per-decoder limit, not a
+  // spec rule. Above-limit values stay an `InvalidRetry` error so
+  // callers can detect adversarial input. The default limit is
+  // 86_400_000 ms (one day); 99_999_999_999 is well above.
+  ssevents.decode_bytes(<<"retry: 99999999999\ndata: ping\n\n":utf8>>)
+  |> should.equal(Error(InvalidRetry("99999999999")))
 }
 
 // WHATWG SSE §9.2.6: id with NUL must be silently ignored, not error.


### PR DESCRIPTION
## Summary

Silently ignore the `retry` field when its value isn't a string of only ASCII digits, per WHATWG SSE §9.2.6. Previously the decoder returned `Error(InvalidRetry(value))` and lost the entire event. The custom `max_retry_value` safety bound (a per-decoder DoS limit, not a spec rule) continues to be a hard error so callers can still detect adversarial input.

## Changes

- `src/ssevents/decoder.gleam`: in `apply_field_parts`, the `"retry"` branch now uses `is_ascii_digit_string` as an outer guard; non-digit values silently advance the byte counter (just like an unknown field) without firing the error path
- `test/ssevents/decoder_test.gleam`:
  - update existing `decode_invalid_retry_test` to expect `Ok([])` for `retry: nope` (the new spec-correct behaviour)
  - add 6 new tests: decimal `12.5`, negative `-100`, empty value, alpha-only, the within-limit baseline (still applied), and the above-limit case (still errors)
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]` flagging the behavioural change in the existing test as a callout

## Design Decisions

`parse_retry` is left intact; it's only called when the value is already known to be all digits, so its internal digit-check is now redundant but harmless. Cleaning it up is a follow-up; this PR's goal is to flip the behaviour with the smallest blast radius.

The `max_retry_value` bound is preserved as a hard error because the spec doesn't speak to it — it's a per-decoder safety knob exposed via `Limits.max_retry_value`. Silently dropping above-limit values would remove the only signal callers have that an adversarial peer is sending huge retry intervals.

Closes #37
