### PR TITLE
fix(decoder): accept lone CR as line separator per WHATWG SSE §9.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Decoder: lone CR (U+000D) is now accepted as a line separator** per
+  WHATWG SSE §9.2.5, alongside CRLF and lone LF. A stream like
+  `data: a\rdata: b\r\r` now decodes the same as the LF-terminated
+  shape (one event with data `"a\nb"`). The incremental decoder still
+  waits when a buffer ends with CR (could become CRLF on the next
+  push), but `finish` on a buffer ending in CR is no longer an
+  `Error(UnexpectedEnd)` — the trailing CR is treated as a lone-CR
+  terminator since no more bytes are coming. (#38)
 - **Decoder: `retry` field that isn't all ASCII digits is now silently
   ignored** per WHATWG SSE §9.2.6, instead of failing the whole decode
   with `Error(InvalidRetry(value))`. Affects `12.5` (decimal),

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -15,7 +15,7 @@ import gleam/option.{type Option, None, Some}
 import gleam/string
 import ssevents/error.{
   type SseError, EventTooLarge, InvalidRetry, InvalidUtf8, LineTooLong,
-  TooManyDataLines, UnexpectedEnd,
+  TooManyDataLines,
 }
 import ssevents/event
 import ssevents/limit
@@ -121,29 +121,44 @@ fn maybe_strip_bom(state: DecodeState) -> DecodeState {
 pub fn finish(state: DecodeState) -> Result(List(event.Item), SseError) {
   case state.buffer {
     <<>> -> finish_event(state)
-    _ ->
-      case ends_with_cr(state.buffer) {
-        True -> Error(UnexpectedEnd)
-        False ->
-          case decode_line(state.buffer) {
+    _ -> {
+      // WHATWG SSE §9.2.5: lone CR is a line terminator. At finish
+      // time no more bytes are coming, so a trailing CR cannot be
+      // the start of a CRLF — treat it as a lone-CR terminator and
+      // process the prefix as the final line.
+      let trimmed = strip_trailing_cr(state.buffer)
+      case decode_line(trimmed) {
+        Error(error) -> Error(error)
+        Ok(line) ->
+          case
+            process_line(
+              DecodeState(..state, buffer: <<>>),
+              line,
+              bit_array.byte_size(trimmed),
+            )
+          {
             Error(error) -> Error(error)
-            Ok(line) ->
-              case
-                process_line(
-                  DecodeState(..state, buffer: <<>>),
-                  line,
-                  bit_array.byte_size(state.buffer),
-                )
-              {
+            Ok(#(state_after_line, emitted)) ->
+              case finish_event(state_after_line) {
                 Error(error) -> Error(error)
-                Ok(#(state_after_line, emitted)) ->
-                  case finish_event(state_after_line) {
-                    Error(error) -> Error(error)
-                    Ok(trailing) -> Ok(list.append(emitted, trailing))
-                  }
+                Ok(trailing) -> Ok(list.append(emitted, trailing))
               }
           }
       }
+    }
+  }
+}
+
+fn strip_trailing_cr(bits: BitArray) -> BitArray {
+  case ends_with_cr(bits) {
+    False -> bits
+    True -> {
+      let size = bit_array.byte_size(bits)
+      case bit_array.slice(bits, 0, size - 1) {
+        Ok(prefix) -> prefix
+        Error(_) -> bits
+      }
+    }
   }
 }
 
@@ -488,12 +503,25 @@ fn find_newline(
   case remaining {
     <<>> -> Ok(None)
 
+    // CR followed by LF: CRLF terminator. Consume both bytes; the
+    // line content stays the same.
+    <<13, 10, rest:bytes>> ->
+      Ok(Some(#(reverse_bytes(acc_rev, <<>>), rest, line_bytes)))
+
+    // CR at the very end of the buffer: ambiguous — the next push may
+    // bring an LF and turn this into CRLF. Wait for more bytes.
+    <<13>> -> Ok(None)
+
+    // CR followed by a non-LF byte: WHATWG SSE §9.2.5 lone-CR
+    // terminator. The CRLF case is matched above so the byte after CR
+    // is guaranteed to not be LF here. Consume only the CR; the
+    // following byte stays in `rest` as the start of the next line.
+    <<13, after_cr:bytes>> ->
+      Ok(Some(#(reverse_bytes(acc_rev, <<>>), after_cr, line_bytes)))
+
+    // Lone LF (no preceding CR — CRLF was caught above).
     <<10, rest:bytes>> ->
-      case acc_rev {
-        <<13, acc_rest:bits>> ->
-          Ok(Some(#(reverse_bytes(acc_rest, <<>>), rest, line_bytes - 1)))
-        _ -> Ok(Some(#(reverse_bytes(acc_rev, <<>>), rest, line_bytes)))
-      }
+      Ok(Some(#(reverse_bytes(acc_rev, <<>>), rest, line_bytes)))
 
     <<byte, rest:bytes>> ->
       find_newline(rest, <<byte, acc_rev:bits>>, line_bytes + 1)

--- a/test/ssevents/decoder_test.gleam
+++ b/test/ssevents/decoder_test.gleam
@@ -251,6 +251,46 @@ pub fn decode_bytes_no_bom_unchanged_test() {
   items |> should.equal([EventItem(ssevents.new("hello"))])
 }
 
+// WHATWG SSE §9.2.5: lone CR (U+000D) is a line terminator alongside
+// CRLF and lone LF.
+
+pub fn decode_lone_cr_line_separator_test() {
+  // `data: a\rdata: b\r\r` is the same shape as `data: a\ndata: b\n\n`
+  // but with lone-CR terminators. Should yield one event with data
+  // "a\nb" (multi-line data lines join with LF per §9.2.6).
+  let body = <<"data: a\rdata: b\r\r":utf8>>
+  let assert Ok([EventItem(event)]) = ssevents.decode_bytes(body)
+  ssevents.data_of(event) |> should.equal("a\nb")
+}
+
+pub fn decode_lone_cr_terminates_event_test() {
+  // Single event terminated by `\r\r` (blank line via lone CR).
+  let body = <<"data: hello\r\r":utf8>>
+  let assert Ok([EventItem(event)]) = ssevents.decode_bytes(body)
+  ssevents.data_of(event) |> should.equal("hello")
+}
+
+pub fn decode_mixed_lone_cr_and_lf_test() {
+  // Mixed terminators in the same stream are legal per §9.2.5.
+  let body = <<"data: a\rdata: b\ndata: c\r\n\r":utf8>>
+  let assert Ok([EventItem(event)]) = ssevents.decode_bytes(body)
+  ssevents.data_of(event) |> should.equal("a\nb\nc")
+}
+
+pub fn finish_with_trailing_lone_cr_test() {
+  // A buffer ending in CR with nothing after is a lone-CR terminator
+  // at finish time (no more bytes are coming).
+  let state = ssevents.new_decoder()
+  let assert Ok(#(state, items1)) =
+    ssevents.push(state, <<"data: hello\r":utf8>>)
+  // CR-at-end is ambiguous mid-stream, so push doesn't emit yet.
+  items1 |> should.equal([])
+  // finish treats the trailing CR as a lone-CR terminator and emits
+  // the unterminated event with `data: hello`.
+  let assert Ok(items) = ssevents.finish(state)
+  items |> should.equal([EventItem(ssevents.new("hello"))])
+}
+
 // WHATWG SSE §9.2.6: retry with non-ASCII-digit value must be
 // silently ignored, not error. The surrounding event still dispatches.
 


### PR DESCRIPTION
## Summary

Accept lone CR (U+000D) as a line separator per WHATWG SSE §9.2.5, which enumerates CR, LF, and CRLF as equivalent terminators. Previously a stream that used lone-CR terminators rejected with `Error(UnexpectedEnd)`; the same shape with LF or CRLF decoded fine.

## Changes

- `src/ssevents/decoder.gleam`:
  - `find_newline` now matches CRLF first (consume both), then waits when the buffer ends in a lone CR (could become CRLF on the next push), then treats a CR followed by a non-LF byte as a lone-CR terminator
  - `finish` no longer errors when the buffer ends in CR — at finish time no more bytes are coming, so the trailing CR is treated as a lone-CR terminator and the prefix is processed as a final line
  - new private `strip_trailing_cr` helper for the `finish` path
  - `UnexpectedEnd` import removed (no longer reachable from the decoder)
- `test/ssevents/decoder_test.gleam`: 4 new tests — pure lone-CR stream, single event with `\r\r` terminator, mixed CR/LF/CRLF in one stream, and `finish` on a buffer ending in lone CR
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]`

## Design Decisions

The lone-CR-followed-by-LF disambiguation uses two-byte lookahead (`<<13, 10, rest:bytes>>`). When the buffer ends in a single CR (`<<13>>`), `find_newline` returns `Ok(None)` so the incremental decoder keeps waiting — this preserves the round-2 chunk-boundary tests that push `data: hello\r` and then `\ndata: world\r\n\r\n` as separate chunks (the `\r` + `\n` join into CRLF). The unambiguous-at-finish case is handled separately in `finish` itself.

`UnexpectedEnd` is no longer reachable from the decoder; the variant stays in `error.gleam` for backwards compatibility (third-party code may still pattern-match on it).

Closes #38
