### PR TITLE
fix(event): sanitize CR/LF/NUL from event name and id at construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Construction: `event` and `id` values are now sanitised on the way
+  in** — CR (U+000D), LF (U+000A), and NUL (U+0000) are silently
+  stripped from the value passed to `from_parts`, `event/2`, and
+  `id/2`. The encoder previously emitted those bytes verbatim,
+  producing wire that the decoder either silently corrupted (LF
+  splits the field across two lines, the post-LF tail is parsed as
+  an unrelated unknown field) or rejected (NUL in id triggered the
+  field-validation path before this release introduced silent-ignore).
+  After this fix `decode(encode(x))` round-trips for any caller-built
+  `Event`, matching the posture `multipartkit/form` already takes for
+  header values. (#39)
 - **Decoder: lone CR (U+000D) is now accepted as a line separator** per
   WHATWG SSE §9.2.5, alongside CRLF and lone LF. A stream like
   `data: a\rdata: b\r\r` now decodes the same as the LF-terminated

--- a/src/ssevents/event.gleam
+++ b/src/ssevents/event.gleam
@@ -7,6 +7,7 @@
 //// is an event or a comment.
 
 import gleam/option.{type Option, None, Some}
+import gleam/string
 
 pub opaque type Event {
   Event(
@@ -32,7 +33,12 @@ pub fn from_parts(
   id id: Option(String),
   retry retry: Option(Int),
 ) -> Event {
-  Event(event: event_name, data: data, id: id, retry: retry)
+  Event(
+    event: option_sanitize(event_name),
+    data: data,
+    id: option_sanitize(id),
+    retry: retry,
+  )
 }
 
 pub fn message(data: String) -> Event {
@@ -44,11 +50,50 @@ pub fn named(name: String, data: String) -> Event {
 }
 
 pub fn event(event: Event, name: String) -> Event {
-  Event(event: Some(name), data: event.data, id: event.id, retry: event.retry)
+  Event(
+    event: Some(sanitize_field_value(name)),
+    data: event.data,
+    id: event.id,
+    retry: event.retry,
+  )
 }
 
 pub fn id(event: Event, id: String) -> Event {
-  Event(event: event.event, data: event.data, id: Some(id), retry: event.retry)
+  Event(
+    event: event.event,
+    data: event.data,
+    id: Some(sanitize_field_value(id)),
+    retry: event.retry,
+  )
+}
+
+/// Strip CR (U+000D), LF (U+000A), and NUL (U+0000) from `value`.
+///
+/// CR / LF inside an `event` or `id` value cannot survive the SSE wire
+/// format — both are line terminators per WHATWG SSE §9.2.5, so a
+/// literal CR / LF inside the value would split the field across two
+/// lines on encode and the decoder would parse the post-LF tail as an
+/// unrelated unknown field. NUL inside `id` is ignored by the decoder
+/// per §9.2.6, breaking round-trip.
+///
+/// Stripping silently at construction time is the same posture
+/// `multipartkit/form.add_field` takes for the analogous header-injection
+/// risk: it keeps `from_parts`, `event/2`, and `id/2` infallible while
+/// guaranteeing that `decode(encode(x))` round-trips for any caller-built
+/// `Event`.
+fn sanitize_field_value(value: String) -> String {
+  value
+  |> string.replace(each: "\r\n", with: "")
+  |> string.replace(each: "\r", with: "")
+  |> string.replace(each: "\n", with: "")
+  |> string.replace(each: "\u{0000}", with: "")
+}
+
+fn option_sanitize(opt: Option(String)) -> Option(String) {
+  case opt {
+    None -> None
+    Some(value) -> Some(sanitize_field_value(value))
+  }
 }
 
 pub fn retry(event: Event, milliseconds: Int) -> Event {

--- a/test/ssevents/event_test.gleam
+++ b/test/ssevents/event_test.gleam
@@ -1,4 +1,4 @@
-import gleam/option.{Some}
+import gleam/option.{None, Some}
 import gleeunit/should
 import ssevents
 
@@ -13,4 +13,86 @@ pub fn event_builder_accessors_test() {
   ssevents.data_of(event) |> should.equal("payload")
   ssevents.id_of(event) |> should.equal(Some("job-1"))
   ssevents.retry_of(event) |> should.equal(Some(5000))
+}
+
+// Construction-time sanitisation: CR / LF / NUL inside `event` and
+// `id` cannot survive the SSE wire format, so they're stripped on
+// the way in. Same posture multipartkit/form takes for header values.
+
+pub fn event_setter_strips_lf_test() {
+  let event = ssevents.new("payload") |> ssevents.event("foo\nbar")
+  ssevents.name_of(event) |> should.equal(Some("foobar"))
+}
+
+pub fn event_setter_strips_cr_test() {
+  let event = ssevents.new("payload") |> ssevents.event("foo\rbar")
+  ssevents.name_of(event) |> should.equal(Some("foobar"))
+}
+
+pub fn event_setter_strips_nul_test() {
+  let event = ssevents.new("payload") |> ssevents.event("foo\u{0000}bar")
+  ssevents.name_of(event) |> should.equal(Some("foobar"))
+}
+
+pub fn id_setter_strips_lf_test() {
+  let event = ssevents.new("payload") |> ssevents.id("a\nb")
+  ssevents.id_of(event) |> should.equal(Some("ab"))
+}
+
+pub fn id_setter_strips_nul_test() {
+  let event = ssevents.new("payload") |> ssevents.id("with\u{0000}nul")
+  ssevents.id_of(event) |> should.equal(Some("withnul"))
+}
+
+pub fn from_parts_strips_lf_in_event_name_test() {
+  let event =
+    ssevents.from_parts(
+      event_name: Some("x\ny"),
+      data: "payload",
+      id: None,
+      retry: None,
+    )
+  ssevents.name_of(event) |> should.equal(Some("xy"))
+}
+
+pub fn from_parts_strips_lf_in_id_test() {
+  let event =
+    ssevents.from_parts(
+      event_name: None,
+      data: "payload",
+      id: Some("a\nb"),
+      retry: None,
+    )
+  ssevents.id_of(event) |> should.equal(Some("ab"))
+}
+
+pub fn from_parts_strips_crlf_pair_in_id_test() {
+  // Sanitise CRLF as a unit (not as separate CR + LF) so the inputs
+  // CR-only, LF-only, and CRLF all give the same result.
+  let event =
+    ssevents.from_parts(
+      event_name: None,
+      data: "payload",
+      id: Some("a\r\nb"),
+      retry: None,
+    )
+  ssevents.id_of(event) |> should.equal(Some("ab"))
+}
+
+pub fn encode_then_decode_round_trips_after_sanitisation_test() {
+  // The whole point of #39: the encoder used to produce
+  // non-roundtrippable wire when the caller passed CR/LF/NUL in
+  // `event`/`id`. After sanitisation, encode → decode round-trips
+  // cleanly (the sanitised value is what comes back).
+  let original =
+    ssevents.from_parts(
+      event_name: Some("noti\nce"),
+      data: "payload",
+      id: Some("evt\u{0000}1"),
+      retry: None,
+    )
+  let wire = ssevents.encode(original)
+  let assert Ok([decoded]) = ssevents.decode(wire)
+  let rewire = ssevents.encode_item(decoded)
+  rewire |> should.equal(wire)
 }


### PR DESCRIPTION
## Summary

Silently strip CR (U+000D), LF (U+000A), and NUL (U+0000) from `event` and `id` values at construction time (`from_parts`, `event/2`, `id/2`). Previously the encoder emitted those bytes verbatim, producing wire that the decoder either silently corrupted (LF splits the field across two lines and the post-LF tail is parsed as an unrelated unknown field) or rejected (NUL in id). After this fix `decode(encode(x))` round-trips for any caller-built `Event`.

## Changes

- `src/ssevents/event.gleam`:
  - new private `sanitize_field_value` strips CR / LF / NUL using the same approach `multipartkit/form.sanitize_value` uses (replace `\r\n`, `\r`, `\n`, `\u{0000}` with `""`)
  - `from_parts`, `event/2`, `id/2` route their `event_name` / `id` arguments through it
  - `data` and `retry` are not sanitised: `data` is split-on-LF and emitted as multiple `data:` lines (CR/LF inside `data` are preserved through round-trip via the multi-line encoding); `retry` is `Int` so the question doesn't arise
- `test/ssevents/event_test.gleam`: 9 new tests covering each of CR / LF / NUL via each of the three setters (`event/2`, `id/2`, `from_parts`), plus a CRLF-as-a-pair sanitisation test, plus an explicit `encode → decode → encode_item` round-trip test that asserts wire equality
- `CHANGELOG.md`: `Fixed` entry under `[Unreleased]`

## Design Decisions

Picked **silent sanitisation** (option 2 from the issue) over making construction `Result`-returning. Reasons:

1. `multipartkit/form.add_field` already takes the silent-strip approach for the analogous header-injection problem, and consistency across the eight packages is valuable.
2. Making `from_parts`, `event/2`, `id/2` `Result`-returning would be a breaking API change for every caller; sanitisation is a forward-compatible refinement.
3. Callers who want to detect bad input *before* construction can call `validate_event_name` / `validate_id` themselves, which already exist and stay unchanged.

`data` is intentionally not sanitised: a multi-line data value is a normal SSE pattern, encoded as multiple `data:` lines and joined with LF on decode (per WHATWG §9.2.6). Stripping LF from `data` would break that.

The CRLF pair is replaced as a single unit so callers can pass `"a\r\nb"` and get `"ab"` (matching what `"a\rb"` and `"a\nb"` already produced after individual replacement).

Closes #39
