### PR TITLE
chore(release): prepare v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-30
+
 ### Fixed
 
 - **Construction: `event` and `id` values are now sanitised on the way

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "ssevents"
-version = "0.2.0"
+version = "0.3.0"
 description = "Server-Sent Events primitives for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "ssevents" }


### PR DESCRIPTION
### Fixed

- **Construction: `event` and `id` values are now sanitised on the way
  in** — CR (U+000D), LF (U+000A), and NUL (U+0000) are silently
  stripped from the value passed to `from_parts`, `event/2`, and
  `id/2`. The encoder previously emitted those bytes verbatim,
  producing wire that the decoder either silently corrupted (LF
  splits the field across two lines, the post-LF tail is parsed as
  an unrelated unknown field) or rejected (NUL in id triggered the
  field-validation path before this release introduced silent-ignore).
  After this fix `decode(encode(x))` round-trips for any caller-built
  `Event`, matching the posture `multipartkit/form` already takes for
  header values. (#39)
- **Decoder: lone CR (U+000D) is now accepted as a line separator** per
  WHATWG SSE §9.2.5, alongside CRLF and lone LF. A stream like
  `data: a\rdata: b\r\r` now decodes the same as the LF-terminated
  shape (one event with data `"a\nb"`). The incremental decoder still
  waits when a buffer ends with CR (could become CRLF on the next
  push), but `finish` on a buffer ending in CR is no longer an
  `Error(UnexpectedEnd)` — the trailing CR is treated as a lone-CR
  terminator since no more bytes are coming. (#38)
- **Decoder: `retry` field that isn't all ASCII digits is now silently
  ignored** per WHATWG SSE §9.2.6, instead of failing the whole decode
  with `Error(InvalidRetry(value))`. Affects `12.5` (decimal),
  `-100` (negative — `-` isn't an ASCII digit), the empty string, and
  any value containing letters or punctuation. The surrounding event
  still dispatches from its other fields. The custom `max_retry_value`
  safety bound (a per-decoder DoS limit, not a spec rule) continues
  to be a hard `Error(InvalidRetry(value))`. **Behavioural change**:
  `decode("retry: nope\n\n")` previously returned
  `Error(InvalidRetry("nope"))`; it now returns `Ok([])` (event has
  no `data:` so nothing to dispatch). (#37)
- **Decoder: `id` field with U+0000 NUL is now silently ignored** per
  WHATWG SSE §9.2.6, instead of failing the entire decode with
  `Error(InvalidField("id"))`. The directive in the spec is to drop
  the *field*, not to fail the *event* — a producer cannot signal
  "ignore the entire event you were assembling" via a malformed id.
  An event with a NUL-tainted id and a valid `data:` line now
  dispatches with the data intact and `id_of(_) == None`. (#36)
- **Decoder: leading UTF-8 BOM (U+FEFF) is now stripped** before
  parsing, per WHATWG SSE §9.2.5. Previously a stream that began
  with the three-byte BOM (`EF BB BF`) — common from UTF-8 emitters
  like `iconv -t UTF-8` and hand-edited fixtures — failed to parse
  the first event. The check runs once per `DecodeState` (tracked
  via a new `bom_handled` flag) and correctly handles the
  incremental decoder when the BOM is split across `push` calls. (#35)
