### PR TITLE
feat(api): add checked Limits constructor and max_data_bytes guard (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- **limit**: `limit.new_checked(...)` returns
+  `Result(Limits, LimitConfigError)` instead of panicking on a
+  non-positive value, and the new `LimitConfigError.NonPositiveLimit(field:, given:)`
+  variant lets callers route configuration failures through their
+  normal result chain. Use this when limit values come from
+  application config, environment variables, or framework settings;
+  the panicking `limit.new` remains the right tool for hard-coded
+  programmer-trusted constants. (#49)
+- **validate**: `validate.max_data_bytes_checked(...)` returns
+  `Result(Result(event.Event, SseError), LimitConfigError)`, splitting
+  argument-validation failures (outer `Error`, configuration-shaped)
+  from event-validation failures (inner `Result`, the existing
+  `EventTooLarge` path). Use this when the size cap is sourced from
+  dynamic input. (#49)
+
 ## [0.3.0] - 2026-04-30
 
 ### Fixed

--- a/src/ssevents/limit.gleam
+++ b/src/ssevents/limit.gleam
@@ -1,8 +1,14 @@
 //// Parser and decoder safety limits.
 ////
-//// These values bound memory growth for the incremental decoder. Each
-//// constructor rejects nonsensical values with a panic so callers do
-//// not silently run with ineffective limits.
+//// These values bound memory growth for the incremental decoder. The
+//// `new` constructor rejects nonsensical values with a panic so callers
+//// do not silently run with ineffective limits. For dynamic input
+//// (config / env / framework), use `new_checked` and surface
+//// `LimitConfigError.NonPositiveLimit` through your normal result
+//// chain.
+
+import gleam/bool
+import gleam/result
 
 pub opaque type Limits {
   Limits(
@@ -11,6 +17,15 @@ pub opaque type Limits {
     max_data_lines: Int,
     max_retry_value: Int,
   )
+}
+
+/// Why a checked limit constructor refused its argument.
+///
+/// `field` names the offending parameter so a single handler can
+/// produce meaningful diagnostics across many checked constructors;
+/// `given` carries the rejected value.
+pub type LimitConfigError {
+  NonPositiveLimit(field: String, given: Int)
 }
 
 pub const default_max_line_bytes = 8192
@@ -78,4 +93,39 @@ pub fn max_data_lines(limits: Limits) -> Int {
 pub fn max_retry_value(limits: Limits) -> Int {
   let Limits(max_retry_value:, ..) = limits
   max_retry_value
+}
+
+/// Like `new`, but returns the argument-validation failure as a
+/// `Result` instead of panicking. Use this when limit values come
+/// from configuration, environment variables, or other dynamic
+/// sources where a malformed value is a recoverable runtime
+/// condition rather than a programmer error.
+///
+/// On success the returned `Limits` is identical to what `new`
+/// would return for the same arguments.
+pub fn new_checked(
+  max_line_bytes max_line_bytes: Int,
+  max_event_bytes max_event_bytes: Int,
+  max_data_lines max_data_lines: Int,
+  max_retry_value max_retry_value: Int,
+) -> Result(Limits, LimitConfigError) {
+  use _ <- result.try(check_min("max_line_bytes", max_line_bytes, 1))
+  use _ <- result.try(check_min("max_event_bytes", max_event_bytes, 1))
+  use _ <- result.try(check_min("max_data_lines", max_data_lines, 1))
+  use _ <- result.try(check_min("max_retry_value", max_retry_value, 0))
+  Ok(Limits(
+    max_line_bytes: max_line_bytes,
+    max_event_bytes: max_event_bytes,
+    max_data_lines: max_data_lines,
+    max_retry_value: max_retry_value,
+  ))
+}
+
+fn check_min(
+  field: String,
+  value: Int,
+  minimum: Int,
+) -> Result(Nil, LimitConfigError) {
+  use <- bool.guard(value < minimum, Error(NonPositiveLimit(field, value)))
+  Ok(Nil)
 }

--- a/src/ssevents/validate.gleam
+++ b/src/ssevents/validate.gleam
@@ -62,7 +62,7 @@ pub fn max_data_bytes_checked(
 ) -> Result(Result(event.Event, SseError), LimitConfigError) {
   case max < 0 {
     True -> Error(NonPositiveLimit("max", max))
-    False -> Ok(max_data_bytes(event, max))
+    False -> Ok(max_data_bytes(event, max: max))
   }
 }
 

--- a/src/ssevents/validate.gleam
+++ b/src/ssevents/validate.gleam
@@ -4,6 +4,7 @@ import gleam/bit_array
 import gleam/int
 import ssevents/error.{type SseError, EventTooLarge, InvalidField, InvalidRetry}
 import ssevents/event
+import ssevents/limit.{type LimitConfigError, NonPositiveLimit}
 
 pub fn validate_event_name(name: String) -> Result(String, SseError) {
   validate_no_forbidden_bytes("event", name)
@@ -44,6 +45,24 @@ pub fn max_data_bytes(
   case data_size > max {
     True -> Error(EventTooLarge(max))
     False -> Ok(event)
+  }
+}
+
+/// Like `max_data_bytes`, but returns the argument-validation failure
+/// as a `LimitConfigError` instead of panicking. Use this when `max`
+/// comes from dynamic input.
+///
+/// The outer `Result` distinguishes argument-validation failures (a
+/// configuration error the caller can surface up the chain) from
+/// event-validation failures (the inner `Result(event.Event, SseError)`
+/// reporting whether the event itself fits the configured limit).
+pub fn max_data_bytes_checked(
+  event: event.Event,
+  max max: Int,
+) -> Result(Result(event.Event, SseError), LimitConfigError) {
+  case max < 0 {
+    True -> Error(NonPositiveLimit("max", max))
+    False -> Ok(max_data_bytes(event, max))
   }
 }
 

--- a/test/ssevents/limit_test.gleam
+++ b/test/ssevents/limit_test.gleam
@@ -2,17 +2,17 @@ import gleeunit/should
 import ssevents/limit
 
 pub fn new_checked_ok_returns_limits_test() {
-  let assert Ok(l) =
+  let assert Ok(limits) =
     limit.new_checked(
       max_line_bytes: 100,
       max_event_bytes: 1000,
       max_data_lines: 10,
       max_retry_value: 5000,
     )
-  l |> limit.max_line_bytes |> should.equal(100)
-  l |> limit.max_event_bytes |> should.equal(1000)
-  l |> limit.max_data_lines |> should.equal(10)
-  l |> limit.max_retry_value |> should.equal(5000)
+  limits |> limit.max_line_bytes |> should.equal(100)
+  limits |> limit.max_event_bytes |> should.equal(1000)
+  limits |> limit.max_data_lines |> should.equal(10)
+  limits |> limit.max_retry_value |> should.equal(5000)
 }
 
 pub fn new_checked_rejects_zero_max_line_bytes_test() {
@@ -24,9 +24,9 @@ pub fn new_checked_rejects_zero_max_line_bytes_test() {
       max_retry_value: 5000,
     )
   {
-    Error(limit.NonPositiveLimit(field: f, given: g)) -> {
-      f |> should.equal("max_line_bytes")
-      g |> should.equal(0)
+    Error(limit.NonPositiveLimit(field: field, given: given)) -> {
+      field |> should.equal("max_line_bytes")
+      given |> should.equal(0)
     }
     Ok(_) -> should.fail()
   }
@@ -41,9 +41,9 @@ pub fn new_checked_rejects_negative_max_event_bytes_test() {
       max_retry_value: 5000,
     )
   {
-    Error(limit.NonPositiveLimit(field: f, given: g)) -> {
-      f |> should.equal("max_event_bytes")
-      g |> should.equal(-1)
+    Error(limit.NonPositiveLimit(field: field, given: given)) -> {
+      field |> should.equal("max_event_bytes")
+      given |> should.equal(-1)
     }
     Ok(_) -> should.fail()
   }
@@ -58,8 +58,8 @@ pub fn new_checked_rejects_zero_max_data_lines_test() {
       max_retry_value: 5000,
     )
   {
-    Error(limit.NonPositiveLimit(field: f, given: _)) ->
-      f |> should.equal("max_data_lines")
+    Error(limit.NonPositiveLimit(field: field, given: _)) ->
+      field |> should.equal("max_data_lines")
     Ok(_) -> should.fail()
   }
 }
@@ -73,20 +73,20 @@ pub fn new_checked_rejects_negative_max_retry_value_test() {
       max_retry_value: -1,
     )
   {
-    Error(limit.NonPositiveLimit(field: f, given: _)) ->
-      f |> should.equal("max_retry_value")
+    Error(limit.NonPositiveLimit(field: field, given: _)) ->
+      field |> should.equal("max_retry_value")
     Ok(_) -> should.fail()
   }
 }
 
 pub fn new_checked_allows_zero_max_retry_value_test() {
   // max_retry_value's panic threshold is < 0, so 0 must be accepted.
-  let assert Ok(l) =
+  let assert Ok(limits) =
     limit.new_checked(
       max_line_bytes: 100,
       max_event_bytes: 1000,
       max_data_lines: 10,
       max_retry_value: 0,
     )
-  l |> limit.max_retry_value |> should.equal(0)
+  limits |> limit.max_retry_value |> should.equal(0)
 }

--- a/test/ssevents/limit_test.gleam
+++ b/test/ssevents/limit_test.gleam
@@ -1,0 +1,92 @@
+import gleeunit/should
+import ssevents/limit
+
+pub fn new_checked_ok_returns_limits_test() {
+  let assert Ok(l) =
+    limit.new_checked(
+      max_line_bytes: 100,
+      max_event_bytes: 1000,
+      max_data_lines: 10,
+      max_retry_value: 5000,
+    )
+  l |> limit.max_line_bytes |> should.equal(100)
+  l |> limit.max_event_bytes |> should.equal(1000)
+  l |> limit.max_data_lines |> should.equal(10)
+  l |> limit.max_retry_value |> should.equal(5000)
+}
+
+pub fn new_checked_rejects_zero_max_line_bytes_test() {
+  case
+    limit.new_checked(
+      max_line_bytes: 0,
+      max_event_bytes: 1000,
+      max_data_lines: 10,
+      max_retry_value: 5000,
+    )
+  {
+    Error(limit.NonPositiveLimit(field: f, given: g)) -> {
+      f |> should.equal("max_line_bytes")
+      g |> should.equal(0)
+    }
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn new_checked_rejects_negative_max_event_bytes_test() {
+  case
+    limit.new_checked(
+      max_line_bytes: 100,
+      max_event_bytes: -1,
+      max_data_lines: 10,
+      max_retry_value: 5000,
+    )
+  {
+    Error(limit.NonPositiveLimit(field: f, given: g)) -> {
+      f |> should.equal("max_event_bytes")
+      g |> should.equal(-1)
+    }
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn new_checked_rejects_zero_max_data_lines_test() {
+  case
+    limit.new_checked(
+      max_line_bytes: 100,
+      max_event_bytes: 1000,
+      max_data_lines: 0,
+      max_retry_value: 5000,
+    )
+  {
+    Error(limit.NonPositiveLimit(field: f, given: _)) ->
+      f |> should.equal("max_data_lines")
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn new_checked_rejects_negative_max_retry_value_test() {
+  case
+    limit.new_checked(
+      max_line_bytes: 100,
+      max_event_bytes: 1000,
+      max_data_lines: 10,
+      max_retry_value: -1,
+    )
+  {
+    Error(limit.NonPositiveLimit(field: f, given: _)) ->
+      f |> should.equal("max_retry_value")
+    Ok(_) -> should.fail()
+  }
+}
+
+pub fn new_checked_allows_zero_max_retry_value_test() {
+  // max_retry_value's panic threshold is < 0, so 0 must be accepted.
+  let assert Ok(l) =
+    limit.new_checked(
+      max_line_bytes: 100,
+      max_event_bytes: 1000,
+      max_data_lines: 10,
+      max_retry_value: 0,
+    )
+  l |> limit.max_retry_value |> should.equal(0)
+}

--- a/test/ssevents/validate_test.gleam
+++ b/test/ssevents/validate_test.gleam
@@ -34,23 +34,23 @@ pub fn validation_helpers_test() {
 }
 
 pub fn max_data_bytes_checked_ok_within_limit_test() {
-  let e = event.new("hi")
-  let assert Ok(inner) = validate.max_data_bytes_checked(e, max: 10)
-  inner |> should.equal(Ok(e))
+  let evt = event.new("hi")
+  let assert Ok(inner) = validate.max_data_bytes_checked(evt, max: 10)
+  inner |> should.equal(Ok(evt))
 }
 
 pub fn max_data_bytes_checked_ok_event_too_large_test() {
-  let e = event.new("hellohello")
-  let assert Ok(inner) = validate.max_data_bytes_checked(e, max: 5)
+  let evt = event.new("hellohello")
+  let assert Ok(inner) = validate.max_data_bytes_checked(evt, max: 5)
   inner |> should.equal(Error(EventTooLarge(5)))
 }
 
 pub fn max_data_bytes_checked_negative_max_returns_config_error_test() {
-  let e = event.new("ok")
-  case validate.max_data_bytes_checked(e, max: -1) {
-    Error(limit.NonPositiveLimit(field: f, given: g)) -> {
-      f |> should.equal("max")
-      g |> should.equal(-1)
+  let evt = event.new("ok")
+  case validate.max_data_bytes_checked(evt, max: -1) {
+    Error(limit.NonPositiveLimit(field: field, given: given)) -> {
+      field |> should.equal("max")
+      given |> should.equal(-1)
     }
     Ok(_) -> should.fail()
   }

--- a/test/ssevents/validate_test.gleam
+++ b/test/ssevents/validate_test.gleam
@@ -1,7 +1,10 @@
 import gleam/string
 import gleeunit/should
 import ssevents
-import ssevents/error.{InvalidField, InvalidRetry}
+import ssevents/error.{EventTooLarge, InvalidField, InvalidRetry}
+import ssevents/event
+import ssevents/limit
+import ssevents/validate
 
 pub fn validation_helpers_test() {
   ssevents.validate_event_name("ok") |> should.equal(Ok("ok"))
@@ -28,4 +31,27 @@ pub fn validation_helpers_test() {
 
   ssevents.validate_retry(0) |> should.equal(Ok(0))
   ssevents.validate_retry(-1) |> should.equal(Error(InvalidRetry("-1")))
+}
+
+pub fn max_data_bytes_checked_ok_within_limit_test() {
+  let e = event.new("hi")
+  let assert Ok(inner) = validate.max_data_bytes_checked(e, max: 10)
+  inner |> should.equal(Ok(e))
+}
+
+pub fn max_data_bytes_checked_ok_event_too_large_test() {
+  let e = event.new("hellohello")
+  let assert Ok(inner) = validate.max_data_bytes_checked(e, max: 5)
+  inner |> should.equal(Error(EventTooLarge(5)))
+}
+
+pub fn max_data_bytes_checked_negative_max_returns_config_error_test() {
+  let e = event.new("ok")
+  case validate.max_data_bytes_checked(e, max: -1) {
+    Error(limit.NonPositiveLimit(field: f, given: g)) -> {
+      f |> should.equal("max")
+      g |> should.equal(-1)
+    }
+    Ok(_) -> should.fail()
+  }
 }


### PR DESCRIPTION
## Summary

Add checked variants for the two helpers that currently panic on a malformed numeric argument, so callers can pass values from application config / environment variables / framework settings without pre-validating them.

## Changes

- `src/ssevents/limit.gleam`
  - new public `LimitConfigError` type with a `NonPositiveLimit(field:, given:)` variant
  - new `new_checked(...)` returning `Result(Limits, LimitConfigError)`
  - the validation chain runs through a `check_min` helper using `bool.guard`
- `src/ssevents/validate.gleam`
  - new `max_data_bytes_checked(...)` returning `Result(Result(event.Event, SseError), LimitConfigError)`
- `test/ssevents/limit_test.gleam` — new file: Ok / per-field / boundary coverage for `new_checked`
- `test/ssevents/validate_test.gleam` — three additional tests for `max_data_bytes_checked` (within limit, event-too-large, negative max)
- `CHANGELOG.md` — `[Unreleased]` entry

## Design Decisions

- Kept the panicking `limit.new` and `validate.max_data_bytes` untouched. The acceptance criteria explicitly preserves both paths, and the panicking variants stay the right tool for trusted constants.
- `LimitConfigError` carries `field: String` and `given: Int` so a single handler can route many checked constructors with meaningful diagnostics. Mirrors the recently-added `multipartkit.LimitConfigError` and oaspec/dataprep checked-constructor patterns.
- Used `bool.guard` + a small `check_min(field, value, minimum)` helper instead of a four-deep nested case. Keeps `new_checked` readable and avoids tripping `deep_nesting`/`prefer_guard_clause` lint.
- `max_data_bytes_checked` returns `Result(Result(_, SseError), LimitConfigError)` (nested) rather than collapsing both errors into a single union. The user is likely to surface the two failure modes through different code paths — a config error means "fix your settings", an `EventTooLarge` means "drop / split the event" — and forcing them into one type would make every call site immediately re-discriminate. The proposal in #49 explicitly suggested this shape.
- Reused `NonPositiveLimit` for the `max_data_bytes_checked` argument (where the threshold is `< 0`, not `< 1`). `field` and `given` together still tell the caller exactly what was rejected; introducing a separate variant for the slightly different threshold would split the error type without buying useful information.

Closes #49
