### PR TITLE
docs: add runnable BEAM/JavaScript integration examples and HTTP guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,16 @@ jobs:
         run: just build-${{ matrix.target }}
       - name: Test
         run: just test-${{ matrix.target }}
+
+  examples:
+    name: Examples build and run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: extractions/setup-just@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "28"
+          gleam-version: "1.15.2"
+      - name: Build and run every example with --warnings-as-errors
+        run: just examples

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 erl_crash.dump
 /doc/reference/*
 .codex
+examples/*/build/
+examples/*/manifest.toml

--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ pub fn reconnect_example(item: ssevents.Item) {
 }
 ```
 
+### Runnable examples
+
+End-to-end snippets — including server-side emit, browser-side
+consumption, HTTP header guidance, and reconnect handling — live
+under [`examples/`](./examples/). Each subdirectory is a self-contained
+Gleam project; run any of them with `cd examples/<name> && gleam run`.
+
 ## Development
 
 ```sh

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,206 @@
+# ssevents examples
+
+Each subdirectory is a self-contained Gleam project that depends on
+`ssevents` via a path dependency. Run any of them with:
+
+```sh
+cd examples/<name>
+gleam run
+```
+
+| Example | What it shows |
+|---|---|
+| `quick_start` | Build a list of SSE items, encode them to a wire-ready byte string, and decode back. The shortest "first success" path. |
+| `streaming_consume` | Drive the incremental decoder with chunks split at awkward boundaries (BOM, mid-event, mid-line) and track `Last-Event-ID` / `retry` so reconnects can resume from the right cursor. |
+| `server_emit` | Produce the sequence of `BitArray` chunks an HTTP server would write to a `text/event-stream` response, plus the response header set every SSE endpoint should send. |
+
+The repository `justfile` has `example-*` recipes that build and run
+each example with `--warnings-as-errors`, and a single `examples`
+recipe that runs them all. CI runs `just examples` on every push.
+
+## HTTP response headers for an SSE endpoint
+
+`ssevents` is runtime-agnostic, but the wire format only works if the
+HTTP server cooperates. Send these headers from whichever framework
+you use:
+
+| Header | Value | Why |
+|---|---|---|
+| `Content-Type` | `text/event-stream` | Mandated by the SSE spec. The constant is exposed as `ssevents.content_type()` so framework adapters can read it without hardcoding. |
+| `Cache-Control` | `no-cache, no-transform` | Prevents intermediaries from caching or rewriting the stream. `no-transform` matters because some proxies will gzip/transcode `text/*` by default. |
+| `Connection` | `keep-alive` | The SSE spec assumes a single long-lived connection. |
+| `X-Accel-Buffering` | `no` | nginx and several ingress controllers buffer responses by default; this header opts the response out of buffering. |
+
+If you serve the endpoint behind a reverse proxy (nginx, Cloudflare,
+an API gateway), confirm that **proxy-level response buffering** is
+disabled for that route. A buffered SSE stream will appear to work
+locally but stall in production.
+
+## Browser client
+
+The browser side is plain JavaScript — `ssevents` does not produce a
+JS client component; the browser already has `EventSource`:
+
+```javascript
+const source = new EventSource("/events", { withCredentials: false });
+
+source.addEventListener("job.started", (e) => {
+  // e.lastEventId carries the `id:` field if the server sent one
+  console.log("started", e.lastEventId, e.data);
+});
+
+source.addEventListener("job.progress", (e) => {
+  console.log("progress", e.data);
+});
+
+source.onerror = () => {
+  // EventSource auto-reconnects honoring the server's `retry:` hint.
+  // It also re-sends `Last-Event-ID` automatically.
+  console.warn("disconnected; will retry");
+};
+```
+
+`EventSource` automatically:
+
+- reconnects on transport errors,
+- honours the most recent `retry:` value the server sent,
+- includes the most recent `id:` in a `Last-Event-ID` request header on
+  every reconnect.
+
+Server-side, decode that header to resume from the right cursor:
+
+```gleam
+import ssevents
+
+pub fn resume_cursor(last_event_id_header: option.Option(String)) {
+  case last_event_id_header {
+    option.Some(cursor) -> resume_from(cursor)
+    option.None -> start_from_head()
+  }
+}
+```
+
+## Server frameworks
+
+`ssevents` does not lock you to a particular HTTP server. The pattern
+is the same for every framework: produce `BitArray` chunks via
+`encode_*_bytes`, then write them to the framework's response stream.
+
+### Mist (low-level HTTP server on the BEAM)
+
+```gleam
+import gleam/erlang/process
+import gleam/http/response
+import mist
+import ssevents
+
+pub fn handler(_request) {
+  let assert Ok(subject) = process.new_subject()
+
+  // Spawn whatever produces events for this client and sends them
+  // as `BitArray` messages to `subject`.
+  spawn_event_source(subject)
+
+  let body =
+    mist.Chunked(stream_from_subject(subject))
+
+  response.new(200)
+  |> response.set_header("content-type", ssevents.content_type())
+  |> response.set_header("cache-control", "no-cache, no-transform")
+  |> response.set_header("x-accel-buffering", "no")
+  |> response.set_body(body)
+}
+```
+
+The `BitArray` chunks come straight out of `ssevents.encode_item_bytes`
+or `ssevents.encode_items_bytes`. See the `server_emit` example for a
+self-contained version of the producer.
+
+### Wisp (request/response framework on top of Mist)
+
+Wisp's `wisp.response_with_body` accepts a streaming body. The shape
+is the same: write `ssevents.encode_item_bytes(item)` chunks as they
+become available, and set the four headers above.
+
+### JavaScript target
+
+On the JavaScript target, the consumer-side `ReadableStream` reader
+gives you `Uint8Array` chunks. Wrap each chunk into a `BitArray` and
+feed it to `ssevents.push`:
+
+```gleam
+import ssevents
+
+pub fn consume_chunk(state: ssevents.DecodeState, chunk: BitArray) {
+  case ssevents.push(state, chunk) {
+    Ok(#(next_state, items)) -> handle_items(next_state, items)
+    Error(error) -> abort(error)
+  }
+}
+```
+
+## Interop with `gleam/yielder` and chunk producers
+
+If your event producer is already a `gleam/yielder.Yielder` of items
+(or of bytes), `ssevents/stream` exposes adapters:
+
+- `ssevents.encode_stream(items: Iterator(Item)) -> Iterator(BitArray)`
+  encodes lazily — convenient when you do not want to materialise the
+  whole list before writing.
+- `ssevents.decode_stream(chunks: Iterator(BitArray)) -> Iterator(Result(Item, SseError))`
+  decodes lazily, surfacing one decoded item per `next` step.
+
+The adapters are thin wrappers over `push` / `finish` and incur no
+extra buffering beyond what the underlying iterator does. They are the
+right fit when you want a single value to flow through the system as a
+stream rather than as a callback.
+
+If you only need to feed bytes one chunk at a time (e.g. from a
+non-iterator API), use `new_decoder` + `push` + `finish` directly —
+that is the path the `streaming_consume` example takes.
+
+## Buffering caveats
+
+- **Proxy buffering**. Always set `X-Accel-Buffering: no` and
+  double-check the proxy config; a buffered stream will appear to work
+  in dev and stall in production.
+- **Heartbeats**. Some clients and proxies close idle connections
+  after 30–60 seconds. Send `ssevents.heartbeat()` (a `: heartbeat`
+  comment) every ~15s to keep the path warm without polluting the
+  event stream.
+- **Compression**. Disable response compression for the SSE route.
+  gzip's framing layer will buffer until the encoder flushes, which
+  defeats the purpose of streaming. `Cache-Control: no-transform`
+  signals this to compliant intermediaries.
+- **HTTP/2**. SSE works fine over HTTP/2 and HTTP/3. There is no need
+  to force HTTP/1.1 unless you have an old client constraint.
+
+## Caching caveats
+
+- Response is **not** cacheable. `Cache-Control: no-cache, no-transform`
+  prevents shared and private caches from storing and replaying it.
+- If you also serve a non-SSE route at the same path with content
+  negotiation, send `Vary: Accept` so caches do not collapse the two.
+- CDN edge nodes typically refuse to cache `text/event-stream`
+  responses; verify with your provider before depending on the
+  behaviour.
+
+## Last-Event-ID and resume semantics
+
+The browser sends `Last-Event-ID: <value>` automatically on reconnect.
+What that value means is up to your server — the spec does not impose
+ordering or persistence. Two common approaches:
+
+- **Cursor**. The id is an opaque cursor into your event log; the
+  server resumes from the next event after that cursor. Easiest to
+  reason about; requires durable storage of past events.
+- **Sequence**. The id is a monotonically increasing sequence number;
+  the server replays events with `id > last_event_id` from a recent
+  buffer. Cheaper to implement; only safe up to the buffer's history
+  window.
+
+Either way, the server-side surface is the same: decode the
+`Last-Event-ID` header on connect, then drive `ssevents.update_reconnect`
+on the items you produce so a downstream `retry` value or `id` change
+is reflected in `last_event_id_header`. See the `streaming_consume`
+example.

--- a/examples/quick_start/gleam.toml
+++ b/examples/quick_start/gleam.toml
@@ -1,0 +1,8 @@
+name = "ssevents_quick_start"
+version = "0.1.0"
+target = "erlang"
+description = "Runnable example: encode an SSE response body and decode it back"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+ssevents = { path = "../.." }

--- a/examples/quick_start/src/ssevents_quick_start.gleam
+++ b/examples/quick_start/src/ssevents_quick_start.gleam
@@ -1,0 +1,59 @@
+//// The shortest "first success" path: build a list of SSE items,
+//// encode them to a wire-ready byte string, then decode back.
+////
+////    cd examples/quick_start
+////    gleam run
+
+import gleam/bit_array
+import gleam/int
+import gleam/io
+import gleam/list
+import gleam/option.{None, Some}
+import ssevents
+import ssevents/event.{Comment, EventItem}
+
+pub fn main() {
+  let items = [
+    ssevents.comment("stream opened"),
+    ssevents.named("job.started", "build #42")
+      |> ssevents.id("cursor-1")
+      |> ssevents.retry(5000)
+      |> ssevents.event_item,
+    ssevents.named("job.progress", "step 1/3\nrunning lints")
+      |> ssevents.id("cursor-2")
+      |> ssevents.event_item,
+    ssevents.heartbeat(),
+  ]
+
+  let body = ssevents.encode_items_bytes(items)
+  io.println(
+    "wrote " <> int.to_string(bit_array.byte_size(body)) <> " bytes of SSE",
+  )
+
+  let assert Ok(decoded) = ssevents.decode_bytes(body)
+  io.println("decoded " <> int.to_string(list.length(decoded)) <> " items:")
+  list.each(decoded, describe)
+}
+
+fn describe(item: ssevents.Item) -> Nil {
+  case item {
+    EventItem(event) -> {
+      let name = case ssevents.name_of(event) {
+        Some(n) -> n
+        None -> "(message)"
+      }
+      let id = case ssevents.id_of(event) {
+        Some(i) -> ", id=" <> i
+        None -> ""
+      }
+      let retry = case ssevents.retry_of(event) {
+        Some(r) -> ", retry=" <> int.to_string(r) <> "ms"
+        None -> ""
+      }
+      io.println(
+        "- event " <> name <> id <> retry <> ": " <> ssevents.data_of(event),
+      )
+    }
+    Comment(text) -> io.println("- comment: " <> text)
+  }
+}

--- a/examples/server_emit/gleam.toml
+++ b/examples/server_emit/gleam.toml
@@ -1,0 +1,8 @@
+name = "ssevents_server_emit"
+version = "0.1.0"
+target = "erlang"
+description = "Runnable example: produce a sequence of byte chunks ready to write as an HTTP text/event-stream response body"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+ssevents = { path = "../.." }

--- a/examples/server_emit/src/ssevents_server_emit.gleam
+++ b/examples/server_emit/src/ssevents_server_emit.gleam
@@ -1,0 +1,92 @@
+//// Build the sequence of byte chunks an HTTP server would write to a
+//// `text/event-stream` response body. The chunks are runtime-agnostic
+//// — pipe them into the response writer of whichever framework you
+//// use (Mist, Wisp, your own).
+////
+////    cd examples/server_emit
+////    gleam run
+////
+//// HTTP-level concerns (which the example deliberately does NOT pull
+//// in as dependencies) are documented in `examples/README.md` and
+//// echoed in the program's output.
+
+import gleam/bit_array
+import gleam/int
+import gleam/io
+import gleam/list
+import ssevents
+
+pub fn main() {
+  io.println("# Required HTTP response headers")
+  list.each(response_headers(), fn(pair) {
+    let #(name, value) = pair
+    io.println("  " <> name <> ": " <> value)
+  })
+
+  io.println("\n# Wire chunks the server would write to the response body")
+
+  let chunks = stream_chunks()
+  list.each(chunks, fn(chunk) {
+    case bit_array.to_string(chunk) {
+      Ok(text) -> io.println("--- chunk ---\n" <> text)
+      Error(_) ->
+        io.println(
+          "--- chunk (binary, "
+          <> int.to_string(bit_array.byte_size(chunk))
+          <> " bytes) ---",
+        )
+    }
+  })
+
+  let total =
+    list.fold(chunks, 0, fn(acc, chunk) { acc + bit_array.byte_size(chunk) })
+  io.println(
+    "\n# Total: "
+    <> int.to_string(list.length(chunks))
+    <> " chunks, "
+    <> int.to_string(total)
+    <> " bytes",
+  )
+}
+
+/// The header set every SSE endpoint should send. `Cache-Control` and
+/// `X-Accel-Buffering` matter especially when an upstream proxy
+/// (nginx, ingress controllers) might otherwise buffer the response.
+pub fn response_headers() -> List(#(String, String)) {
+  [
+    #("Content-Type", ssevents.content_type()),
+    #("Cache-Control", "no-cache, no-transform"),
+    #("Connection", "keep-alive"),
+    #("X-Accel-Buffering", "no"),
+  ]
+}
+
+/// One encoded `BitArray` per logical write. Each encoded item ends in
+/// a blank line, so the client decoder can dispatch as soon as the
+/// chunk lands — there is no need to coalesce writes.
+fn stream_chunks() -> List(BitArray) {
+  let opening = [
+    ssevents.comment("stream opened"),
+    ssevents.named("retry.hint", "use 5s")
+      |> ssevents.retry(5000)
+      |> ssevents.event_item,
+  ]
+
+  let updates = [
+    ssevents.named("job.started", "build #42")
+      |> ssevents.id("cursor-1")
+      |> ssevents.event_item,
+    ssevents.named("job.progress", "step 1/3\nrunning lints")
+      |> ssevents.id("cursor-2")
+      |> ssevents.event_item,
+    ssevents.heartbeat(),
+    ssevents.named("job.finished", "ok")
+      |> ssevents.id("cursor-3")
+      |> ssevents.event_item,
+  ]
+
+  [
+    ssevents.encode_items_bytes(opening),
+    ..list.map(updates, ssevents.encode_item_bytes)
+  ]
+}

--- a/examples/streaming_consume/gleam.toml
+++ b/examples/streaming_consume/gleam.toml
@@ -1,0 +1,8 @@
+name = "ssevents_streaming_consume"
+version = "0.1.0"
+target = "erlang"
+description = "Runnable example: consume an SSE stream chunk-by-chunk and track reconnect metadata"
+
+[dependencies]
+gleam_stdlib = ">= 0.44.0 and < 2.0.0"
+ssevents = { path = "../.." }

--- a/examples/streaming_consume/src/ssevents_streaming_consume.gleam
+++ b/examples/streaming_consume/src/ssevents_streaming_consume.gleam
@@ -1,0 +1,118 @@
+//// Drive the incremental decoder with a real-world-shaped chunk
+//// sequence and track the reconnect metadata (`Last-Event-ID`,
+//// `retry`) that a client should remember across reconnects.
+////
+////    cd examples/streaming_consume
+////    gleam run
+////
+//// In production code, the chunks would come from your HTTP client of
+//// choice (e.g. an `httpc` / `gleam_fetch` body stream on the BEAM, or
+//// a `ReadableStream` reader on the JavaScript target). The decoder
+//// itself is runtime-agnostic.
+
+import gleam/bit_array
+import gleam/int
+import gleam/io
+import gleam/list
+import gleam/option.{None, Some}
+import ssevents
+import ssevents/event.{Comment, EventItem}
+
+pub fn main() {
+  let chunks = wire_chunks()
+
+  io.println(
+    "feeding " <> int.to_string(list.length(chunks)) <> " chunks of input",
+  )
+
+  let assert Ok(#(state, items)) = drain(ssevents.new_decoder(), chunks, [])
+  let assert Ok(trailing) = ssevents.finish(state)
+  let all_items = list.append(items, trailing)
+
+  io.println("\n# Items emitted")
+  list.each(all_items, describe)
+
+  io.println("\n# Reconnect metadata after the stream")
+  let reconnect =
+    list.fold(all_items, ssevents.new_reconnect_state(), fn(acc, item) {
+      ssevents.update_reconnect(acc, item)
+    })
+
+  case ssevents.last_event_id(reconnect) {
+    Some(id) -> io.println("- last event id: " <> id)
+    None -> io.println("- last event id: (none)")
+  }
+  case ssevents.retry_interval(reconnect) {
+    Some(ms) -> io.println("- retry interval: " <> int.to_string(ms) <> "ms")
+    None -> io.println("- retry interval: (none — keep client default)")
+  }
+  case ssevents.last_event_id_header(reconnect) {
+    Some(#(header, value)) ->
+      io.println("- send on reconnect: " <> header <> ": " <> value)
+    None -> io.println("- send on reconnect: (no header — first connect)")
+  }
+}
+
+fn drain(
+  state: ssevents.DecodeState,
+  chunks: List(BitArray),
+  emitted_rev: List(ssevents.Item),
+) -> Result(#(ssevents.DecodeState, List(ssevents.Item)), ssevents.SseError) {
+  case chunks {
+    [] -> Ok(#(state, list.reverse(emitted_rev)))
+    [chunk, ..rest] ->
+      case ssevents.push(state, chunk) {
+        Error(error) -> Error(error)
+        Ok(#(next_state, items)) ->
+          drain(
+            next_state,
+            rest,
+            list.reverse(items) |> list.append(emitted_rev),
+          )
+      }
+  }
+}
+
+/// A handcrafted byte stream that mimics what an HTTP client would
+/// actually pull from a `text/event-stream` response: a leading UTF-8
+/// BOM, an event split across two reads, a multi-line `data` field,
+/// and a heartbeat comment.
+fn wire_chunks() -> List(BitArray) {
+  [
+    <<0xEF, 0xBB, 0xBF>>,
+    <<"retry: 5000\n":utf8>>,
+    <<"id: cursor-1\nevent: job.s":utf8>>,
+    <<"tarted\ndata: build #42\n\n":utf8>>,
+    <<": heartbeat\n":utf8>>,
+    <<"id: cursor-2\nevent: job.progress\ndata: step 1/3\ndata: running":utf8>>,
+    <<" lints\n\n":utf8>>,
+  ]
+}
+
+fn describe(item: ssevents.Item) -> Nil {
+  case item {
+    EventItem(event) -> {
+      let name = case ssevents.name_of(event) {
+        Some(n) -> n
+        None -> "(message)"
+      }
+      let id = case ssevents.id_of(event) {
+        Some(i) -> ", id=" <> i
+        None -> ""
+      }
+      io.println("- event " <> name <> id <> ": " <> describe_data(event))
+    }
+    Comment(text) -> io.println("- comment: " <> text)
+  }
+}
+
+fn describe_data(event: ssevents.Event) -> String {
+  let data = ssevents.data_of(event)
+  case bit_array.byte_size(bit_array.from_string(data)) > 64 {
+    True ->
+      "("
+      <> int.to_string(bit_array.byte_size(bit_array.from_string(data)))
+      <> " bytes)"
+    False -> data
+  }
+}

--- a/justfile
+++ b/justfile
@@ -55,7 +55,20 @@ check: clean
   gleam build --warnings-as-errors
   gleam test
 
-ci: deps check build-javascript test-javascript
+ci: deps check build-javascript test-javascript examples
+
+# Build and run every runnable example under examples/ with
+# --warnings-as-errors. CI runs this on every push.
+examples: example-quick-start example-streaming-consume example-server-emit
+
+example-quick-start:
+  cd examples/quick_start && gleam deps download && gleam build --warnings-as-errors && gleam run
+
+example-streaming-consume:
+  cd examples/streaming_consume && gleam deps download && gleam build --warnings-as-errors && gleam run
+
+example-server-emit:
+  cd examples/server_emit && gleam deps download && gleam build --warnings-as-errors && gleam run
 
 all: clean deps
   gleam format --check src/ test/
@@ -66,6 +79,7 @@ all: clean deps
   gleam test --target erlang
   gleam test --target javascript
   gleam docs build
+  just examples
   @echo ""
   @echo "All checks passed."
 


### PR DESCRIPTION
## Summary

Adds first-party integration examples and HTTP guidance for `ssevents`, addressing the gap between "the library explains the primitives well" and "how do I wire this into a real BEAM server / browser client".

New top-level structure:

- `examples/` — three self-contained Gleam projects, each depending on `ssevents` via a path dependency. CI runs all three with `--warnings-as-errors`.
- `examples/README.md` — comprehensive guidance covering required HTTP response headers, browser `EventSource` patterns, framework integration (Mist, Wisp), `gleam/yielder` interop, buffering / caching caveats, and `Last-Event-ID` resume semantics.

The three runnable examples:

- **`quick_start`** — the shortest "first success" path: build a list of SSE items, encode to bytes, decode back, and pretty-print.
- **`streaming_consume`** — drives the incremental decoder with a chunk sequence that mimics what an HTTP client would actually pull from a `text/event-stream` response (BOM, mid-event splits, multi-line `data`), then prints the reconnect metadata (`Last-Event-ID`, `retry`) the client should remember on disconnect.
- **`server_emit`** — produces the sequence of `BitArray` chunks an HTTP server would write to the response body, plus the response header set every SSE endpoint should send. Runtime-agnostic — the chunks plug into Mist, Wisp, or any HTTP server's chunked-write API.

Other changes:

- `.github/workflows/ci.yml` — new `examples` job that runs `just examples` on every push, ensuring the examples stay compile-checked across changes to the core API.
- `justfile` — adds `example-quick-start`, `example-streaming-consume`, `example-server-emit`, and aggregate `examples` recipes; the `ci` and `all` recipes now include `examples`.
- `.gitignore` — ignores `examples/*/build/` and `examples/*/manifest.toml`.
- `README.md` — adds a one-paragraph pointer to `examples/`.

## Design Decisions

- **Compile-checked over fully-runnable HTTP servers.** The acceptance criteria allow either; fully-runnable Mist/Wisp servers would lock the example projects to specific versions of those frameworks, which is hostile to long-term maintenance and adds a non-trivial Erlang/OTP dependency surface to CI. The `server_emit` example produces the exact `BitArray` sequence a real handler would write, with concrete Mist/Wisp wiring snippets in `examples/README.md` instead.
- **`EventSource` is the browser story.** Browsers ship `EventSource` already; there's no value in shipping a Gleam-on-JS client that wraps it. The README documents the JS pattern with a copy-paste-ready snippet plus the server-side `Last-Event-ID` resume hook in Gleam.
- **No new core deps.** Each example pulls in only `gleam_stdlib` plus the path-`ssevents`. CI overhead stays small.
- **Example-level constructors via `ssevents/event.{Comment, EventItem}`.** The `ssevents` facade re-exports types as aliases but not constructors; the existing tests and the new examples reach into `ssevents/event` for `Comment` / `EventItem` when pattern-matching on `Item`. Idiomatic for downstream code as well.

## Verification

Locally on Erlang:

- `gleam format --check src/ test/`, `gleam check`, `gleam run -m glinter`
- `gleam test --target erlang` — 95 passed
- `cd examples/quick_start && gleam build --warnings-as-errors && gleam run` — clean
- `cd examples/streaming_consume && gleam build --warnings-as-errors && gleam run` — clean, prints reconnect metadata
- `cd examples/server_emit && gleam build --warnings-as-errors && gleam run` — clean, prints headers + chunks

Closes #46
