### PR TITLE
fix(encoder): walk bytes once when normalising CR / CRLF (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **encoder**: `normalise_newlines` now rewrites every CRLF / lone CR
+  to LF in a single byte-level pass. The previous two-pass
+  `string.replace` shape could leak a lone CR into the wire on the
+  BEAM for inputs whose `\r\n` neighbours another `\r` — e.g.
+  `" 0Az~\n\r\r\n"` produced wire bytes containing a literal `CR`
+  inside a `data:` line, breaking `decode(encode(event))`
+  round-tripping. The single-pass walker is also robust against
+  whatever the underlying `string.replace` does on each target. (#58)
+
 ## [0.6.0] - 2026-05-04
 
 ### Documentation

--- a/src/ssevents/encoder.gleam
+++ b/src/ssevents/encoder.gleam
@@ -146,7 +146,31 @@ fn line_ending_to_string(line_ending: LineEnding) -> String {
 }
 
 fn normalise_newlines(text: String) -> String {
-  text
-  |> string.replace(each: "\r\n", with: "\n")
-  |> string.replace(each: "\r", with: "\n")
+  // Walk the bytes once and rewrite every CRLF / lone CR to LF in a
+  // single pass. The two-pass `string.replace` shape this replaced
+  // could leave a stray CR behind on the BEAM for inputs like
+  // `"a\n\r\r\n"` — the first pass consumes the trailing `\r\n`,
+  // and the lone `\r` survives the second pass because of how
+  // `:binary.replace` handles the surrounding LF context. (#58)
+  //
+  // The walker only substitutes individual ASCII bytes, so a valid
+  // UTF-8 input remains valid UTF-8 — `let assert` here is a
+  // total-function declaration, not error swallowing.
+  // nolint: assert_ok_pattern -- ASCII-only byte substitution preserves UTF-8 validity
+  let assert Ok(s) =
+    text
+    |> bit_array.from_string
+    |> walk_normalise_newlines(<<>>)
+    |> bit_array.to_string
+  s
+}
+
+fn walk_normalise_newlines(input: BitArray, acc: BitArray) -> BitArray {
+  case input {
+    <<>> -> acc
+    <<13, 10, rest:bytes>> -> walk_normalise_newlines(rest, <<acc:bits, 10>>)
+    <<13, rest:bytes>> -> walk_normalise_newlines(rest, <<acc:bits, 10>>)
+    <<byte, rest:bytes>> -> walk_normalise_newlines(rest, <<acc:bits, byte>>)
+    _ -> acc
+  }
 }

--- a/test/ssevents/encoder_test.gleam
+++ b/test/ssevents/encoder_test.gleam
@@ -4,6 +4,7 @@ import gleam/option.{Some}
 import gleeunit/should
 import ssevents
 import ssevents/encoder
+import ssevents/event
 
 pub fn encode_multiline_event_with_lf_test() {
   let event =
@@ -100,4 +101,47 @@ pub fn encode_items_bytes_matches_item_concatenation_test() {
     |> list.map(ssevents.encode_item_bytes)
     |> bit_array.concat,
   )
+}
+
+pub fn encode_normalises_lone_cr_between_lf_pair_test() {
+  // Regression for #58: input " 0Az~\n\r\r\n" used to leak a lone CR
+  // into the wire because the second-pass `string.replace("\r", "\n")`
+  // failed to rewrite the surviving CR after the first pass had
+  // consumed `\r\n`. The single-pass byte walker rewrites every CRLF
+  // and lone CR to LF.
+  let event = ssevents.new(" 0Az~\n\r\r\n")
+  let wire = ssevents.encode(event)
+
+  // No CR byte must appear anywhere in the encoded output.
+  bit_array.from_string(wire)
+  |> contains_byte(13)
+  |> should.equal(False)
+
+  // The data field must round-trip through encode/decode losslessly.
+  let assert Ok([decoded_item]) = ssevents.decode(wire)
+  let assert event.EventItem(decoded_event) = decoded_item
+  ssevents.data_of(decoded_event)
+  |> should.equal(" 0Az~\n\n\n")
+}
+
+pub fn encode_normalises_isolated_cr_test() {
+  // A lone CR with no trailing LF must also normalise to LF.
+  let event = ssevents.new("a\rb")
+  let wire = ssevents.encode(event)
+
+  bit_array.from_string(wire)
+  |> contains_byte(13)
+  |> should.equal(False)
+}
+
+fn contains_byte(input: BitArray, target: Int) -> Bool {
+  case input {
+    <<>> -> False
+    <<byte, rest:bytes>> ->
+      case byte == target {
+        True -> True
+        False -> contains_byte(rest, target)
+      }
+    _ -> False
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #58 — `encoder.encode` could leak a lone CR into the wire for
inputs whose `\r\n` neighboured another `\r`, breaking
`decode(encode(event))` round-tripping.

## Approach

The previous `normalise_newlines` chained two `string.replace` calls
(`\r\n -> \n`, then `\r -> \n`). On the BEAM, the second pass could
leave a lone CR untouched when surrounded by LF bytes — for the
shrunk metamon input `" 0Az~\n\r\r\n"` the first pass consumed the
trailing `\r\n` and the surviving `\r` survived into the encoded wire,
producing `data: \r\n` and breaking the round-trip.

The new implementation walks the input as a `BitArray` once,
rewriting every CRLF and isolated CR to LF in a single pass. The
walker only substitutes individual ASCII bytes, so a valid UTF-8
input remains valid UTF-8.

## Tests

- `encode_normalises_lone_cr_between_lf_pair_test`: encodes the #58
  reproduction input, asserts no CR byte appears in the wire, and
  asserts `decode(encode(event))` returns `" 0Az~\n\n\n"`.
- `encode_normalises_isolated_cr_test`: pins the lone-CR case
  (`"a\rb"`).

## Test plan

- [x] `just check` (clean format-check + glinter + check + build + test)
- [ ] CI green on Erlang and JavaScript lanes
