### PR TITLE
fix(decoder): drop one byte not one grapheme for the optional leading space (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   inside a `data:` line, breaking `decode(encode(event))`
   round-tripping. The single-pass walker is also robust against
   whatever the underlying `string.replace` does on each target. (#58)
+- **decoder**: `trim_optional_leading_space` (used for the optional
+  U+0020 SPACE after the field colon) now drops a single ASCII byte
+  via `BitArray` slicing rather than calling
+  `string.drop_start(.., up_to: 1)`. The latter operates on grapheme
+  clusters, so when the byte after the space was a combining mark
+  such as U+1B00 BALINESE SIGN ULU RICEM or U+0301 COMBINING ACUTE
+  ACCENT, the whole `space + mark` cluster was deleted and the mark
+  was silently lost on decode. The fix applies to `event:`, `id:`,
+  and comment lines (which share the helper). (#59)
 
 ## [0.6.0] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   round-tripping. The single-pass walker is also robust against
   whatever the underlying `string.replace` does on each target. (#58)
 - **decoder**: `trim_optional_leading_space` (used for the optional
-  U+0020 SPACE after the field colon) now drops a single ASCII byte
-  via `BitArray` slicing rather than calling
-  `string.drop_start(.., up_to: 1)`. The latter operates on grapheme
-  clusters, so when the byte after the space was a combining mark
-  such as U+1B00 BALINESE SIGN ULU RICEM or U+0301 COMBINING ACUTE
-  ACCENT, the whole `space + mark` cluster was deleted and the mark
-  was silently lost on decode. The fix applies to `event:`, `id:`,
-  and comment lines (which share the helper). (#59)
+  U+0020 SPACE after the field colon) now drops a single UTF-8
+  code point rather than calling `string.drop_start(.., up_to: 1)`.
+  The latter operates on grapheme clusters, so when the byte after
+  the space was a combining mark such as U+1B00 BALINESE SIGN ULU
+  RICEM or U+0301 COMBINING ACUTE ACCENT, the whole `space + mark`
+  cluster was deleted and the mark was silently lost on decode.
+  The fix uses `string.to_utf_codepoints` so it is grapheme-cluster-
+  agnostic and also BOM-safe on JavaScript (where round-tripping
+  through `bit_array.to_string` would have stripped a leading
+  U+FEFF). The fix applies to `event:`, `id:`, and comment lines
+  (which share the helper). (#59)
 
 ## [0.6.0] - 2026-05-04
 

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -441,22 +441,31 @@ fn split_field_bytes(
 }
 
 fn trim_optional_leading_space(value: String) -> String {
-  // WHATWG SSE §9.2.6: drop a leading U+0020 SPACE if present. The
-  // earlier `string.drop_start(.., up_to: 1)` operates on grapheme
-  // clusters, so when the byte after the space is a combining mark
-  // (e.g. U+0301, U+1B00) it deletes the whole `space + mark`
-  // cluster and silently strips the mark on decode. Slice past the
-  // single ASCII space byte instead so we drop exactly U+0020. (#59)
-  case bit_array.from_string(value) {
-    <<32, rest:bytes>> -> {
-      // Skipping a single complete UTF-8 codepoint (U+0020 = 1 byte)
-      // leaves the remainder valid UTF-8 if the input was, so the
-      // assert is a totality declaration, not error swallowing.
-      // nolint: assert_ok_pattern -- skipping U+0020 preserves UTF-8 validity
-      let assert Ok(s) = bit_array.to_string(rest)
-      s
-    }
-    _ -> value
+  // WHATWG SSE §9.2.6: drop a leading U+0020 SPACE if present.
+  //
+  // The earlier `string.drop_start(.., up_to: 1)` operated on
+  // grapheme clusters, so when the byte after the space was a
+  // combining mark (e.g. U+0301, U+1B00) the whole `space + mark`
+  // cluster was deleted and the mark was silently stripped on
+  // decode. `string.split_once` and other `string` helpers share
+  // the same grapheme semantics, so they have the same defect.
+  // Going through `BitArray` doesn't help either: on the
+  // JavaScript target `bit_array.to_string` runs through a
+  // `TextDecoder` whose default `ignoreBOM` is `false`, so a
+  // leading U+FEFF after the space would be stripped instead of
+  // preserved.
+  //
+  // Operate on UTF-8 code points instead. If the first code point
+  // is U+0020, drop it and rebuild the string from the remaining
+  // code points. This is grapheme-cluster-agnostic and BOM-safe.
+  // (#59)
+  case string.to_utf_codepoints(value) {
+    [first, ..rest] ->
+      case string.utf_codepoint_to_int(first) == 0x20 {
+        True -> string.from_utf_codepoints(rest)
+        False -> value
+      }
+    [] -> value
   }
 }
 

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -441,9 +441,22 @@ fn split_field_bytes(
 }
 
 fn trim_optional_leading_space(value: String) -> String {
-  case string.starts_with(value, " ") {
-    True -> string.drop_start(from: value, up_to: 1)
-    False -> value
+  // WHATWG SSE §9.2.6: drop a leading U+0020 SPACE if present. The
+  // earlier `string.drop_start(.., up_to: 1)` operates on grapheme
+  // clusters, so when the byte after the space is a combining mark
+  // (e.g. U+0301, U+1B00) it deletes the whole `space + mark`
+  // cluster and silently strips the mark on decode. Slice past the
+  // single ASCII space byte instead so we drop exactly U+0020. (#59)
+  case bit_array.from_string(value) {
+    <<32, rest:bytes>> -> {
+      // Skipping a single complete UTF-8 codepoint (U+0020 = 1 byte)
+      // leaves the remainder valid UTF-8 if the input was, so the
+      // assert is a totality declaration, not error swallowing.
+      // nolint: assert_ok_pattern -- skipping U+0020 preserves UTF-8 validity
+      let assert Ok(s) = bit_array.to_string(rest)
+      s
+    }
+    _ -> value
   }
 }
 

--- a/test/ssevents/decoder_test.gleam
+++ b/test/ssevents/decoder_test.gleam
@@ -425,3 +425,36 @@ fn push_chunks(
       }
   }
 }
+
+pub fn decode_preserves_combining_mark_after_leading_space_test() {
+  // Regression for #59: U+1B00 BALINESE SIGN ULU RICEM after a
+  // leading space used to be dropped because
+  // `string.drop_start(.., up_to: 1)` removed the whole `space +
+  // combining-mark` grapheme cluster instead of the single
+  // U+0020 byte.
+  let wire = "event: \u{1B00}X\ndata: x\n\n"
+  let assert Ok([EventItem(decoded)]) = ssevents.decode(wire)
+  ssevents.name_of(decoded) |> should.equal(Some("\u{1B00}X"))
+  ssevents.data_of(decoded) |> should.equal("x")
+}
+
+pub fn decode_preserves_combining_acute_after_leading_space_test() {
+  // Same defect class with U+0301 COMBINING ACUTE ACCENT.
+  let wire = "event: \u{0301}E\n\n"
+  let assert Ok([EventItem(decoded)]) = ssevents.decode(wire)
+  ssevents.name_of(decoded) |> should.equal(Some("\u{0301}E"))
+}
+
+pub fn decode_comment_preserves_combining_mark_after_leading_space_test() {
+  // `decode_comment_text` shares the same trim helper, so the same
+  // bug surfaced for comments.
+  let wire = ": \u{1B00}note\n\n"
+  let assert Ok([Comment(text)]) = ssevents.decode(wire)
+  text |> should.equal("\u{1B00}note")
+}
+
+pub fn decode_id_preserves_combining_mark_after_leading_space_test() {
+  let wire = "id: \u{0301}1\ndata: x\n\n"
+  let assert Ok([EventItem(decoded)]) = ssevents.decode(wire)
+  ssevents.id_of(decoded) |> should.equal(Some("\u{0301}1"))
+}

--- a/test/ssevents/decoder_test.gleam
+++ b/test/ssevents/decoder_test.gleam
@@ -458,3 +458,14 @@ pub fn decode_id_preserves_combining_mark_after_leading_space_test() {
   let assert Ok([EventItem(decoded)]) = ssevents.decode(wire)
   ssevents.id_of(decoded) |> should.equal(Some("\u{0301}1"))
 }
+
+pub fn decode_preserves_bom_after_leading_space_test() {
+  // Regression for the JS-target footgun in #59: an initial fix
+  // that round-tripped through BitArray would stripping a U+FEFF
+  // sitting immediately after the optional space, because
+  // `TextDecoder` defaults to `ignoreBOM: false`. The codepoint-
+  // based trim preserves it.
+  let wire = "data: \u{FEFF}x\n\n"
+  let assert Ok([EventItem(decoded)]) = ssevents.decode(wire)
+  ssevents.data_of(decoded) |> should.equal("\u{FEFF}x")
+}


### PR DESCRIPTION
## Summary

Fixes #59 — the decoder silently dropped a combining mark (U+0301,
U+1B00, ...) that followed the optional U+0020 SPACE after a field
colon, breaking round-tripping for events whose name / id / comment
text started with such a codepoint.

## Approach

The helper used `string.drop_start(.., up_to: 1)`, which operates on
grapheme clusters. When the byte after the space was a combining
mark, the call removed the whole `space + mark` cluster instead of
just the U+0020.

Switched to a `BitArray` pattern match: peel the leading ASCII space
byte with `<<32, rest:bytes>>` and reassemble via
`bit_array.to_string(rest)`. The input was a `String`, so removing
one complete UTF-8 codepoint (U+0020 = 1 byte) leaves the remainder
valid UTF-8 — the `let assert Ok(..)` is a totality declaration, not
error swallowing.

The same helper backs `decode_comment_text`, so comment lines benefit
automatically.

## Tests

- `decode_preserves_combining_mark_after_leading_space_test`: U+1B00
  on `event:`.
- `decode_preserves_combining_acute_after_leading_space_test`: U+0301
  on `event:`.
- `decode_comment_preserves_combining_mark_after_leading_space_test`:
  comment-line variant.
- `decode_id_preserves_combining_mark_after_leading_space_test`:
  `id:` variant.

## Test plan

- [x] `just check` (clean format-check + glinter + check + build + test)
- [ ] CI green on Erlang and JavaScript lanes
