### PR TITLE
fix(event): coerce out-of-range retry to None at construction (#60)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   through `bit_array.to_string` would have stripped a leading
   U+FEFF). The fix applies to `event:`, `id:`, and comment lines
   (which share the helper). (#59)
+- **event**: `event.retry/2` and `event.from_parts(retry: Some(_))`
+  now silently coerce out-of-range retry values to `None` at
+  construction. Previously a negative `Some(n)` survived into the
+  wire output but was dropped by §9.2.6's ASCII-digits rule on
+  decode, and a value above `limit.default_max_retry_value`
+  (24 hours in milliseconds) hard-failed the default decoder with
+  `InvalidRetry`. `decode(encode(event))` now round-trips for any
+  caller-built `Event` — matching the silent-sanitisation posture
+  already used for CR / LF / NUL inside `event:` and `id:` (#39). (#60)
 
 ## [0.6.0] - 2026-05-04
 

--- a/src/ssevents/event.gleam
+++ b/src/ssevents/event.gleam
@@ -8,6 +8,7 @@
 
 import gleam/option.{type Option, None, Some}
 import gleam/string
+import ssevents/limit
 
 pub opaque type Event {
   Event(
@@ -37,7 +38,7 @@ pub fn from_parts(
     event: option_sanitize(event_name),
     data: data,
     id: option_sanitize(id),
-    retry: retry,
+    retry: sanitize_retry(retry),
   )
 }
 
@@ -101,8 +102,30 @@ pub fn retry(event: Event, milliseconds: Int) -> Event {
     event: event.event,
     data: event.data,
     id: event.id,
-    retry: Some(milliseconds),
+    retry: sanitize_retry(Some(milliseconds)),
   )
+}
+
+/// Drop retry values that the SSE wire format / decoder will not
+/// round-trip back to `Some(n)` under the default `Limits`.
+///
+/// WHATWG SSE §9.2.6 only recognises retry values whose textual form
+/// is ASCII digits, so a negative value would be silently dropped on
+/// decode. Values above `limit.default_max_retry_value` (24 hours in
+/// milliseconds) hard-fail the default decoder. Coercing both to
+/// `None` here matches the silent-sanitisation posture
+/// `sanitize_field_value` takes for `event:` and `id:`, so
+/// `decode(encode(event))` returns the same event for any caller-built
+/// `Event`. (#60)
+fn sanitize_retry(retry: Option(Int)) -> Option(Int) {
+  case retry {
+    None -> None
+    Some(ms) ->
+      case ms < 0 || ms > limit.default_max_retry_value {
+        True -> None
+        False -> Some(ms)
+      }
+  }
 }
 
 pub fn data(event: Event, data: String) -> Event {

--- a/test/ssevents/event_test.gleam
+++ b/test/ssevents/event_test.gleam
@@ -96,3 +96,80 @@ pub fn encode_then_decode_round_trips_after_sanitisation_test() {
   let rewire = ssevents.encode_item(decoded)
   rewire |> should.equal(wire)
 }
+
+// Construction-time sanitisation for `retry`: a negative value is
+// silently dropped on decode by §9.2.6 ASCII-digits rule, and any
+// value above the default 24-hour cap hard-fails the decoder. Both
+// shapes are coerced to `None` at construction so encode → decode
+// is a no-op.
+
+pub fn retry_setter_drops_negative_test() {
+  let event = ssevents.new("payload") |> ssevents.retry(-100)
+  ssevents.retry_of(event) |> should.equal(None)
+}
+
+pub fn retry_setter_drops_value_above_default_max_test() {
+  // limit.default_max_retry_value == 86_400_000 (24h in ms).
+  let event = ssevents.new("payload") |> ssevents.retry(1_000_000_000)
+  ssevents.retry_of(event) |> should.equal(None)
+}
+
+pub fn retry_setter_keeps_zero_test() {
+  // Zero is a legal retry value (immediate reconnect).
+  let event = ssevents.new("payload") |> ssevents.retry(0)
+  ssevents.retry_of(event) |> should.equal(Some(0))
+}
+
+pub fn retry_setter_keeps_default_max_boundary_test() {
+  let event = ssevents.new("payload") |> ssevents.retry(86_400_000)
+  ssevents.retry_of(event) |> should.equal(Some(86_400_000))
+}
+
+pub fn from_parts_drops_negative_retry_test() {
+  let event =
+    ssevents.from_parts(
+      event_name: None,
+      data: "payload",
+      id: None,
+      retry: Some(-100),
+    )
+  ssevents.retry_of(event) |> should.equal(None)
+}
+
+pub fn from_parts_drops_out_of_range_retry_test() {
+  let event =
+    ssevents.from_parts(
+      event_name: None,
+      data: "payload",
+      id: None,
+      retry: Some(1_000_000_000),
+    )
+  ssevents.retry_of(event) |> should.equal(None)
+}
+
+pub fn encode_decode_round_trips_after_retry_sanitisation_test() {
+  // Regression for #60: prior versions emitted `retry: -100` /
+  // `retry: 1000000000` and the decoder either silently dropped or
+  // hard-failed.
+  let neg =
+    ssevents.from_parts(
+      event_name: None,
+      data: "x",
+      id: None,
+      retry: Some(-100),
+    )
+  let assert Ok([decoded_neg]) = ssevents.decode(ssevents.encode(neg))
+  ssevents.encode_item(decoded_neg)
+  |> should.equal(ssevents.encode(neg))
+
+  let huge =
+    ssevents.from_parts(
+      event_name: None,
+      data: "x",
+      id: None,
+      retry: Some(1_000_000_000),
+    )
+  let assert Ok([decoded_huge]) = ssevents.decode(ssevents.encode(huge))
+  ssevents.encode_item(decoded_huge)
+  |> should.equal(ssevents.encode(huge))
+}


### PR DESCRIPTION
## Summary

Fixes #60 — `event.retry/2` and `event.from_parts(retry: Some(_))`
accepted negative or out-of-range retry values, and the resulting
wire was either silently dropped or hard-rejected by the default
decoder.

## Approach

`retry/2` and `from_parts(retry: ..)` now route through a new
`sanitize_retry` helper that coerces `Some(n)` to `None` when
`n < 0` or `n > limit.default_max_retry_value` (24 hours in
milliseconds). This mirrors the silent-sanitisation posture
`sanitize_field_value` already takes for CR / LF / NUL inside
`event:` and `id:` (#39), so `decode(encode(event))` is a no-op
for any caller-built `Event`.

## Tests

- Setter drops negative retry / out-of-range retry / keeps zero /
  keeps default-max boundary (4 cases)
- `from_parts` drops negative / out-of-range retry (2 cases)
- `encode_decode_round_trips_after_retry_sanitisation_test`: pins
  the round-trip for the two metamon-shrunk inputs (`Some(-100)`,
  `Some(1_000_000_000)`)

## Test plan

- [x] `just check` (clean format-check + glinter + check + build + test)
- [ ] CI green on Erlang and JavaScript lanes
