### PR TITLE
fix(encoder): strip CR / LF from Comment text to keep round-trip law (#61)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `InvalidRetry`. `decode(encode(event))` now round-trips for any
   caller-built `Event` — matching the silent-sanitisation posture
   already used for CR / LF / NUL inside `event:` and `id:` (#39). (#60)
+- **encoder**: `encode_item(Comment(text))` now strips CR / LF from
+  `text` before emitting the wire `:` line. Previously any embedded
+  line break fanned the comment out to one `:` line per fragment
+  (`Comment("a\nb")` → `: a\n: b\n`), and `decoder.decode` surfaced
+  the result as N separate `Comment` values, breaking the round-
+  trip law `decode(encode(item)) == [item]`. WHATWG SSE §9.2.6 has
+  no notion of a multi-line comment, so silently sanitising matches
+  the same posture taken for `event:` / `id:` in #39. (#61)
 
 ## [0.6.0] - 2026-05-04
 

--- a/src/ssevents/encoder.gleam
+++ b/src/ssevents/encoder.gleam
@@ -116,12 +116,26 @@ fn encode_comment_with_line_ending(
 ) -> String {
   let newline = line_ending_to_string(line_ending)
 
+  // WHATWG SSE §9.2.6 has no notion of a multi-line comment, so a
+  // `Comment(text)` whose `text` contained CR / LF used to fan out
+  // to one `:` line per fragment; `decoder.decode` would then
+  // surface each line as a separate `Comment`, breaking the
+  // round-trip law `decode(encode(item)) == [item]`. Strip CR / LF
+  // here so a `Comment` is always emitted as a single `:` line —
+  // same silent-sanitisation posture `sanitize_field_value` takes
+  // for `event:` and `id:` (#39). (#61)
+  let sanitised = strip_line_breaks(text)
+  comment_line(sanitised) <> newline
+}
+
+fn strip_line_breaks(text: String) -> String {
   text
-  |> normalise_newlines
-  |> string.split(on: "\n")
-  |> list.map(comment_line)
-  |> list.map(fn(line) { line <> newline })
-  |> string.concat
+  |> string.to_utf_codepoints
+  |> list.filter(fn(cp) {
+    let codepoint = string.utf_codepoint_to_int(cp)
+    codepoint != 0x0D && codepoint != 0x0A
+  })
+  |> string.from_utf_codepoints
 }
 
 fn comment_line(text: String) -> String {

--- a/test/ssevents/encoder_test.gleam
+++ b/test/ssevents/encoder_test.gleam
@@ -134,6 +134,42 @@ pub fn encode_normalises_isolated_cr_test() {
   |> should.equal(False)
 }
 
+pub fn encode_comment_strips_lf_to_keep_round_trip_test() {
+  // Regression for #61: previously `Comment("a\nb")` encoded to
+  // `: a\n: b\n` and decoded back to two separate `Comment`
+  // values. Stripping CR / LF inside the comment text keeps the
+  // decoder yielding a single `Comment` — same posture
+  // `sanitize_field_value` takes for `event:` and `id:`.
+  let item = event.Comment("a\nb")
+  let wire = ssevents.encode_item(item)
+  let assert Ok(decoded) = ssevents.decode(wire)
+  decoded |> should.equal([event.Comment("ab")])
+}
+
+pub fn encode_comment_strips_cr_test() {
+  let item = event.Comment("a\rb")
+  let wire = ssevents.encode_item(item)
+  let assert Ok(decoded) = ssevents.decode(wire)
+  decoded |> should.equal([event.Comment("ab")])
+}
+
+pub fn encode_comment_strips_crlf_pair_test() {
+  let item = event.Comment("a\r\nb")
+  let wire = ssevents.encode_item(item)
+  let assert Ok(decoded) = ssevents.decode(wire)
+  decoded |> should.equal([event.Comment("ab")])
+}
+
+pub fn encode_comment_round_trips_to_single_comment_test() {
+  // After stripping the encoded wire is exactly one `:` line, so
+  // decode returns exactly one `Comment` matching the sanitised
+  // input.
+  let item = event.Comment("multi\nline\rdiagnostic")
+  let wire = ssevents.encode_item(item)
+  let assert Ok(decoded) = ssevents.decode(wire)
+  decoded |> should.equal([event.Comment("multilinediagnostic")])
+}
+
 fn contains_byte(input: BitArray, target: Int) -> Bool {
   case input {
     <<>> -> False


### PR DESCRIPTION
## Summary

Fixes #61 — `encode_item(Comment("a\nb"))` produced `: a\n: b\n` and
decoded back to two separate `Comment` values, breaking the round-
trip law `decode(encode(item)) == [item]`.

## Approach

WHATWG SSE §9.2.6 has no notion of a multi-line comment. Silently
strip CR / LF from the comment text before emitting the wire `:`
line, matching the silent-sanitisation posture
`sanitize_field_value` already takes for CR / LF / NUL inside
`event:` and `id:` (#39).

The strip is implemented at the UTF-8 code-point level
(`string.to_utf_codepoints |> list.filter |> string.from_utf_codepoints`),
which side-steps the cross-target `string.replace` quirk addressed
in #58.

## Tests

- LF, CR, and CRLF inside `Comment` text → encoded as one `:` line,
  decoded back as a single `Comment` carrying the sanitised text.
- Mixed CR / LF diagnostic-shape input
  (`"multi\nline\rdiagnostic"`) round-trips to a single
  `Comment("multilinediagnostic")`.

## Test plan

- [x] `just check` (clean format-check + glinter + check + build + test)
- [ ] CI green on Erlang and JavaScript lanes
