### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-05-06
+
 ### Fixed
 
 - **encoder**: `normalise_newlines` now rewrites every CRLF / lone CR

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "ssevents"
-version = "0.6.0"
+version = "0.7.0"
 description = "Server-Sent Events primitives for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "ssevents" }


### PR DESCRIPTION
### Fixed

- **encoder**: `normalise_newlines` now rewrites every CRLF / lone CR
  to LF in a single byte-level pass. The previous two-pass
  `string.replace` shape could leak a lone CR into the wire on the
  BEAM for inputs whose `\r\n` neighbours another `\r` — e.g.
  `" 0Az~\n\r\r\n"` produced wire bytes containing a literal `CR`
  inside a `data:` line, breaking `decode(encode(event))`
  round-tripping. The single-pass walker is also robust against
  whatever the underlying `string.replace` does on each target. (#58)
- **decoder**: `trim_optional_leading_space` (used for the optional
  U+0020 SPACE after the field colon) now drops a single UTF-8
  code point rather than calling `string.drop_start(.., up_to: 1)`.
  The latter operates on grapheme clusters, so when the byte after
  the space was a combining mark such as U+1B00 BALINESE SIGN ULU
  RICEM or U+0301 COMBINING ACUTE ACCENT, the whole `space + mark`
  cluster was deleted and the mark was silently lost on decode.
  The fix uses `string.to_utf_codepoints` so it is grapheme-cluster-
  agnostic and also BOM-safe on JavaScript (where round-tripping
  through `bit_array.to_string` would have stripped a leading
  U+FEFF). The fix applies to `event:`, `id:`, and comment lines
  (which share the helper). (#59)
- **event**: `event.retry/2` and `event.from_parts(retry: Some(_))`
  now silently coerce out-of-range retry values to `None` at
  construction. Previously a negative `Some(n)` survived into the
  wire output but was dropped by §9.2.6's ASCII-digits rule on
  decode, and a value above `limit.default_max_retry_value`
  (24 hours in milliseconds) hard-failed the default decoder with
  `InvalidRetry`. `decode(encode(event))` now round-trips for any
  caller-built `Event` — matching the silent-sanitisation posture
  already used for CR / LF / NUL inside `event:` and `id:` (#39). (#60)
- **encoder**: `encode_item(Comment(text))` now strips CR / LF from
  `text` before emitting the wire `:` line. Previously any embedded
  line break fanned the comment out to one `:` line per fragment
  (`Comment("a\nb")` → `: a\n: b\n`), and `decoder.decode` surfaced
  the result as N separate `Comment` values, breaking the round-
  trip law `decode(encode(item)) == [item]`. WHATWG SSE §9.2.6 has
  no notion of a multi-line comment, so silently sanitising matches
  the same posture taken for `event:` / `id:` in #39. (#61)
