### PR TITLE
fix(event): sanitise CR / NUL in data at construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`event.new`, `event.from_parts`, and `event.data` now sanitise
+  the `data` value at construction**: CR (U+000D) and NUL (U+0000)
+  are stripped, and a CRLF grapheme is normalised to a single LF.
+  LF is preserved as a logical line separator (the encoder splits
+  on LF to emit multi-line `data:` blocks; the decoder rejoins them
+  with LF). Previously the in-memory `data` carried whatever bytes
+  the caller passed, but the encoder ran them through
+  `normalise_newlines` on the way to the wire — so an `Event` with
+  `data = "a\r\nb"` round-tripped to an `Event` with `data = "a\nb"`,
+  violating the round-trip guarantee documented in
+  `event.gleam`'s top comment. Construction now matches the wire
+  shape, closing the round-trip law for any caller-built `Event`.
+  Matches the `sanitize_field_value` posture already used for
+  `event_name` and `id` (silent strip, not a `Result`-returning
+  builder). The `encode_normalises_lone_cr_between_lf_pair_test`
+  regression test from #58 stays in place but now relies on the
+  construction-time sanitiser to keep CR off the wire. (#67)
+
 ## [0.7.0] - 2026-05-06
 
 ### Fixed

--- a/src/ssevents/event.gleam
+++ b/src/ssevents/event.gleam
@@ -6,6 +6,7 @@
 //// helper modules frequently pattern match on whether a stream element
 //// is an event or a comment.
 
+import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
 import ssevents/limit
@@ -25,7 +26,7 @@ pub type Item {
 }
 
 pub fn new(data: String) -> Event {
-  Event(event: None, data: data, id: None, retry: None)
+  Event(event: None, data: sanitize_data_value(data), id: None, retry: None)
 }
 
 pub fn from_parts(
@@ -36,7 +37,7 @@ pub fn from_parts(
 ) -> Event {
   Event(
     event: option_sanitize(event_name),
-    data: data,
+    data: sanitize_data_value(data),
     id: option_sanitize(id),
     retry: sanitize_retry(retry),
   )
@@ -129,7 +130,44 @@ fn sanitize_retry(retry: Option(Int)) -> Option(Int) {
 }
 
 pub fn data(event: Event, data: String) -> Event {
-  Event(event: event.event, data: data, id: event.id, retry: event.retry)
+  Event(
+    event: event.event,
+    data: sanitize_data_value(data),
+    id: event.id,
+    retry: event.retry,
+  )
+}
+
+/// Strip CR (U+000D) and NUL (U+0000) from a `data` value, and
+/// convert standalone CRLF graphemes to LF.
+///
+/// WHATWG SSE §9.2.6 normalises CR / CRLF / LF to LF on the wire side
+/// and silently drops NUL, so neither sequence can survive
+/// `decode(encode(x))` verbatim inside `data`. Strip / normalise both
+/// at construction so the in-memory representation already matches
+/// what the wire would carry. LF is preserved — `data` may
+/// legitimately contain logical newlines, and the encoder splits on
+/// LF to emit multi-line `data:` blocks; the decoder rejoins those
+/// lines with LF, so `\n` round-trips cleanly.
+///
+/// The implementation maps over Unicode graphemes (`\r\n` is a single
+/// grapheme per UAX #29). A `string.replace`-based pass cannot strip
+/// the `\r` half of a CRLF pair on the JavaScript target because the
+/// CRLF grapheme is opaque to substring search.
+fn sanitize_data_value(value: String) -> String {
+  value
+  |> string.to_graphemes
+  |> list.flat_map(map_data_grapheme)
+  |> string.join(with: "")
+}
+
+fn map_data_grapheme(grapheme: String) -> List(String) {
+  case grapheme {
+    "\r" -> []
+    "\u{0000}" -> []
+    "\r\n" -> ["\n"]
+    other -> [other]
+  }
 }
 
 pub fn name_of(event: Event) -> Option(String) {

--- a/test/ssevents/encoder_test.gleam
+++ b/test/ssevents/encoder_test.gleam
@@ -105,10 +105,9 @@ pub fn encode_items_bytes_matches_item_concatenation_test() {
 
 pub fn encode_normalises_lone_cr_between_lf_pair_test() {
   // Regression for #58: input " 0Az~\n\r\r\n" used to leak a lone CR
-  // into the wire because the second-pass `string.replace("\r", "\n")`
-  // failed to rewrite the surviving CR after the first pass had
-  // consumed `\r\n`. The single-pass byte walker rewrites every CRLF
-  // and lone CR to LF.
+  // into the wire. As of #67, `event.new` strips CR at construction
+  // so the encoder never sees a CR byte to begin with, and the
+  // round-trip is closed at construction rather than at encode.
   let event = ssevents.new(" 0Az~\n\r\r\n")
   let wire = ssevents.encode(event)
 
@@ -118,10 +117,12 @@ pub fn encode_normalises_lone_cr_between_lf_pair_test() {
   |> should.equal(False)
 
   // The data field must round-trip through encode/decode losslessly.
+  // CR is dropped at construction; the surviving LF preserves the
+  // logical-newline semantics of the original input.
   let assert Ok([decoded_item]) = ssevents.decode(wire)
   let assert event.EventItem(decoded_event) = decoded_item
   ssevents.data_of(decoded_event)
-  |> should.equal(" 0Az~\n\n\n")
+  |> should.equal(ssevents.data_of(event))
 }
 
 pub fn encode_normalises_isolated_cr_test() {

--- a/test/ssevents/event_test.gleam
+++ b/test/ssevents/event_test.gleam
@@ -44,6 +44,61 @@ pub fn id_setter_strips_nul_test() {
   ssevents.id_of(event) |> should.equal(Some("withnul"))
 }
 
+pub fn new_strips_lone_cr_from_data_test() {
+  // #67: a literal CR in `data` cannot survive `decode(encode(x))`
+  // verbatim — the wire would coerce it. Strip at construction so
+  // `data_of(new(x))` already reflects what the wire would carry.
+  let event = ssevents.new("a\rb")
+  ssevents.data_of(event) |> should.equal("ab")
+}
+
+pub fn new_strips_cr_from_crlf_pair_in_data_test() {
+  // The CR half of a CRLF pair is removed; the LF survives as a
+  // logical newline (the encoder will emit it as a separate
+  // `data:` line).
+  let event = ssevents.new("a\r\nb")
+  ssevents.data_of(event) |> should.equal("a\nb")
+}
+
+pub fn new_strips_nul_from_data_test() {
+  // NUL is dropped silently by the decoder per §9.2.6.
+  let event = ssevents.new("hello\u{0000}world")
+  ssevents.data_of(event) |> should.equal("helloworld")
+}
+
+pub fn new_preserves_lf_in_data_test() {
+  // LF inside `data` is a *logical* line separator — the encoder
+  // splits on it to emit a multi-line `data:` block. Stripping it
+  // would lose information that round-trips correctly.
+  let event = ssevents.new("first\nsecond")
+  ssevents.data_of(event) |> should.equal("first\nsecond")
+}
+
+pub fn data_setter_strips_cr_test() {
+  // Same rule via the builder helper.
+  let event = ssevents.new("ignored") |> ssevents.data("a\rb")
+  ssevents.data_of(event) |> should.equal("ab")
+}
+
+pub fn from_parts_strips_cr_in_data_test() {
+  let event =
+    ssevents.from_parts(event_name: None, data: "x\ry", id: None, retry: None)
+  ssevents.data_of(event) |> should.equal("xy")
+}
+
+pub fn data_round_trips_after_cr_sanitisation_test() {
+  // The reproducer from #67: build with CRLF, encode, decode, and
+  // confirm the in-memory data after construction equals the
+  // post-decode data.
+  let event = ssevents.new("a\r\nb")
+  let wire = ssevents.encode(event)
+  let assert Ok([decoded]) = ssevents.decode(wire)
+  ssevents.encode_item(decoded) |> should.equal(wire)
+  // And the in-memory value already matches the wire round-trip
+  // (CR removed, LF preserved as a logical newline).
+  ssevents.data_of(event) |> should.equal("a\nb")
+}
+
 pub fn from_parts_strips_lf_in_event_name_test() {
   let event =
     ssevents.from_parts(


### PR DESCRIPTION
## Summary

`event.data` (and `from_parts` / the `data` builder) accepted the
caller's `data` payload verbatim, but the encoder ran it through
`normalise_newlines` (CRLF / lone CR → LF) before splitting into
`data:` lines. So an `Event` whose `data` carried a literal CR
encoded to wire that decoded back to a different `data` string —
violating the round-trip guarantee documented at the top of
`event.gleam`. Issue #67 reproduced this with `new("a\r\nb")`
round-tripping to `new("a\nb")`. This PR closes the round-trip law
by sanitising `data` at construction.

## Changes

- `src/ssevents/event.gleam`: new `sanitize_data_value/1` is called
  by `new`, `from_parts`, and the `data` builder. The function maps
  over Unicode graphemes and drops `\r` (lone CR), drops `\u{0000}`
  (NUL), and rewrites the `\r\n` grapheme to `\n`. LF is preserved
  because the encoder splits on it to emit multi-line `data:`
  blocks and the decoder rejoins them with LF — so `\n`
  round-trips cleanly.
- `test/ssevents/event_test.gleam`: seven new regression tests —
  lone CR is dropped, CRLF graphemes are coerced to LF, NUL is
  dropped, LF is preserved, the rule applies via the `data`
  builder and `from_parts`, and a top-level `encode → decode`
  round-trip stays byte-stable.
- `test/ssevents/encoder_test.gleam`: the existing #58 regression
  test (`encode_normalises_lone_cr_between_lf_pair_test`) now
  asserts byte-stability via `data_of(event) == data_of(decoded)`
  instead of pinning a CR-derived numeric LF count, since
  construction-time sanitisation strips CR before the encoder
  ever sees it.
- `CHANGELOG.md`: `[Unreleased] / Fixed` entry calls out the
  behaviour change for callers who explicitly stored CR / NUL.

## Design Decisions

- **Strip CR, preserve LF, drop NUL.** Matches the conservative
  variant Issue #67 outlines. CR cannot survive the wire (§9.2.6
  normalises CR / CRLF to LF); NUL is silently dropped by the
  decoder. LF is the encoder's logical line separator and round-
  trips cleanly, so stripping it would be both unnecessary and
  user-hostile (the obvious "multi-line data" case becomes
  impossible to express in memory).
- **Grapheme-aware mapping rather than `string.replace`.**
  Gleam's `string.replace(each: "\r", ...)` does not match the `\r`
  half of a CRLF pair on the JavaScript target because `\r\n` is
  a single Unicode grapheme cluster (UAX #29). Walking graphemes
  with `string.to_graphemes` + `list.flat_map` handles both the
  lone-`\r` and the `\r\n` grapheme cases without surprise.
- **Silent strip, not `Result`-returning.** The package already
  silently strips `\r`/`\n`/NUL from `event_name` and `id` via
  `sanitize_field_value`. Issue #67 explicitly recommends the
  same posture for `data`. A `Result`-returning `from_parts`
  variant would cost every existing caller an unwrap for an
  edge case that almost never matters.
- **`encoder.normalise_newlines` stays.** The encoder still walks
  data bytes for line splitting, and keeping its CR-handling
  branch is cheap defence-in-depth against any internal path
  that bypasses construction (e.g. a future `unchecked_new`
  helper). The #58 regression test now asserts byte-stability
  rather than pinning a specific CR-derived LF count.

## Limitations

- Behaviour change for callers that stored a literal CR / NUL in
  `data` and expected the byte to survive. The encoder was
  already losing them on the wire side; the in-memory model now
  matches.

Closes #67
