### PR TITLE
refactor(event)!: make Comment opaque with sanitising smart constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `Item` variant is renamed `Comment(String)` → `CommentItem(Comment)`.
   Construct a `Comment` via the new smart constructor
   `event.comment(text: String) -> Comment`, which strips CR / LF /
-  NUL at construction (the same posture taken for `event_name`,
-  `id`, and the `data` field). Inspect with
+  NUL at construction (the same posture taken for `event_name` and
+  `id` — comments cannot be multi-line per WHATWG SSE §9.2.6, so
+  unlike `data` no LF is preserved). Inspect with
   `event.comment_text_of(c) -> String`. The convenience
   `event.comment_item(text)` wraps the two-step
   `CommentItem(comment(text))`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed (BREAKING)
+- **`Comment` is now an opaque type** in `ssevents/event` and the
+  `Item` variant is renamed `Comment(String)` → `CommentItem(Comment)`.
+  Construct a `Comment` via the new smart constructor
+  `event.comment(text: String) -> Comment`, which strips CR / LF /
+  NUL at construction (the same posture taken for `event_name`,
+  `id`, and the `data` field). Inspect with
+  `event.comment_text_of(c) -> String`. The convenience
+  `event.comment_item(text)` wraps the two-step
+  `CommentItem(comment(text))`.
+
+  Why: WHATWG SSE §9.2.6 has no notion of a multi-line comment, so
+  any embedded line break in a `Comment` value would fan out to
+  multiple `:` lines on the wire and the decoder would surface them
+  as separate `Comment` items — breaking
+  `decode(encode([CommentItem(c)])) == [CommentItem(c)]`. Closing
+  the round-trip law at construction is the same fix shape as #67
+  for `Event.data`. The `encode_item` / `decode` paths now rely on
+  the construction-time invariant; the encoder no longer needs the
+  `strip_line_breaks` workaround that #61 introduced.
+
+  Migration:
+  - `event.Comment(text)` constructor → `event.comment(text)` (or
+    `event.comment_item(text)` if you immediately want an `Item`).
+  - Pattern match `event.Comment(text)` → `event.CommentItem(c)`
+    plus `let text = event.comment_text_of(c)`.
+
+  The facade helper `ssevents.comment(text)` is unchanged on the
+  surface — it still returns an `Item`, matching the previous
+  behaviour. Built-in examples (`quick_start`, `streaming_consume`)
+  and tests are updated. (#68)
+
 ### Fixed
 - **`event.new`, `event.from_parts`, and `event.data` now sanitise
   the `data` value at construction**: CR (U+000D) and NUL (U+0000)

--- a/examples/quick_start/src/ssevents_quick_start.gleam
+++ b/examples/quick_start/src/ssevents_quick_start.gleam
@@ -10,7 +10,7 @@ import gleam/io
 import gleam/list
 import gleam/option.{None, Some}
 import ssevents
-import ssevents/event.{Comment, EventItem}
+import ssevents/event.{CommentItem, EventItem}
 
 pub fn main() {
   let items = [
@@ -54,6 +54,6 @@ fn describe(item: ssevents.Item) -> Nil {
         "- event " <> name <> id <> retry <> ": " <> ssevents.data_of(event),
       )
     }
-    Comment(text) -> io.println("- comment: " <> text)
+    CommentItem(c) -> io.println("- comment: " <> event.comment_text_of(c))
   }
 }

--- a/examples/streaming_consume/src/ssevents_streaming_consume.gleam
+++ b/examples/streaming_consume/src/ssevents_streaming_consume.gleam
@@ -16,7 +16,7 @@ import gleam/io
 import gleam/list
 import gleam/option.{None, Some}
 import ssevents
-import ssevents/event.{Comment, EventItem}
+import ssevents/event.{CommentItem, EventItem}
 
 pub fn main() {
   let chunks = wire_chunks()
@@ -102,7 +102,7 @@ fn describe(item: ssevents.Item) -> Nil {
       }
       io.println("- event " <> name <> id <> ": " <> describe_data(event))
     }
-    Comment(text) -> io.println("- comment: " <> text)
+    CommentItem(c) -> io.println("- comment: " <> event.comment_text_of(c))
   }
 }
 

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -224,8 +224,10 @@ fn process_line(
         True ->
           Ok(
             #(state, [
-              event.Comment(
-                decode_comment_text(string.drop_start(from: line, up_to: 1)),
+              event.CommentItem(
+                event.comment(
+                  decode_comment_text(string.drop_start(from: line, up_to: 1)),
+                ),
               ),
             ]),
           )

--- a/src/ssevents/encoder.gleam
+++ b/src/ssevents/encoder.gleam
@@ -58,7 +58,8 @@ pub fn encode_item_with_line_ending(
 ) -> String {
   case item {
     event.EventItem(ev) -> encode_with_line_ending(ev, line_ending)
-    event.Comment(text) -> encode_comment_with_line_ending(text, line_ending)
+    event.CommentItem(c) ->
+      encode_comment_with_line_ending(event.comment_text_of(c), line_ending)
   }
 }
 
@@ -114,28 +115,11 @@ fn encode_comment_with_line_ending(
   text: String,
   line_ending: LineEnding,
 ) -> String {
+  // The `Comment` opaque is sanitised at construction (#68), so by
+  // the time the encoder sees `text` it cannot contain CR / LF / NUL.
+  // Emit a single `:` line.
   let newline = line_ending_to_string(line_ending)
-
-  // WHATWG SSE §9.2.6 has no notion of a multi-line comment, so a
-  // `Comment(text)` whose `text` contained CR / LF used to fan out
-  // to one `:` line per fragment; `decoder.decode` would then
-  // surface each line as a separate `Comment`, breaking the
-  // round-trip law `decode(encode(item)) == [item]`. Strip CR / LF
-  // here so a `Comment` is always emitted as a single `:` line —
-  // same silent-sanitisation posture `sanitize_field_value` takes
-  // for `event:` and `id:` (#39). (#61)
-  let sanitised = strip_line_breaks(text)
-  comment_line(sanitised) <> newline
-}
-
-fn strip_line_breaks(text: String) -> String {
-  text
-  |> string.to_utf_codepoints
-  |> list.filter(fn(cp) {
-    let codepoint = string.utf_codepoint_to_int(cp)
-    codepoint != 0x0D && codepoint != 0x0A
-  })
-  |> string.from_utf_codepoints
+  comment_line(text) <> newline
 }
 
 fn comment_line(text: String) -> String {

--- a/src/ssevents/event.gleam
+++ b/src/ssevents/event.gleam
@@ -1,10 +1,11 @@
 //// Event and item domain values.
 ////
-//// `Event` is opaque so the package can evolve its representation
-//// without a breaking change. Construct via `new`, `from_parts`, and
-//// the builder helpers. `Item` stays transparent because callers and
-//// helper modules frequently pattern match on whether a stream element
-//// is an event or a comment.
+//// `Event` and `Comment` are opaque so the package can evolve their
+//// representation without a breaking change. Construct via `new`,
+//// `from_parts`, and the builder helpers (for `Event`) or `comment`
+//// (for `Comment`). `Item` stays transparent so callers and helper
+//// modules can pattern match on whether a stream element is an event
+//// or a comment.
 
 import gleam/list
 import gleam/option.{type Option, None, Some}
@@ -20,9 +21,42 @@ pub opaque type Event {
   )
 }
 
+/// A `:`-prefixed comment line in an SSE stream.
+///
+/// Opaque — construct with `comment/1` and inspect with
+/// `comment_text_of/1`. Comment text is sanitised at construction
+/// (CR / LF / NUL stripped) so `decode(encode([CommentItem(c)]))`
+/// returns the same `Comment` value: WHATWG SSE §9.2.6 has no
+/// notion of a multi-line comment, so any embedded line break would
+/// fan out to multiple comments on the wire and break the
+/// round-trip law.
+pub opaque type Comment {
+  Comment(text: String)
+}
+
 pub type Item {
   EventItem(Event)
-  Comment(String)
+  CommentItem(Comment)
+}
+
+/// Build a `Comment` from a text payload. CR (U+000D), LF (U+000A),
+/// and NUL (U+0000) are stripped at construction so the result
+/// round-trips through `encode → decode` without fanning out into
+/// multiple comments. Matches the `sanitize_field_value` posture
+/// already used for `event_name` and `id`.
+pub fn comment(text: String) -> Comment {
+  Comment(text: sanitize_field_value(text))
+}
+
+/// Extract the sanitised comment text.
+pub fn comment_text_of(c: Comment) -> String {
+  c.text
+}
+
+/// Wrap a `Comment` as a stream item. Convenience for the common
+/// `CommentItem(comment(text))` two-step.
+pub fn comment_item(text: String) -> Item {
+  CommentItem(comment(text))
 }
 
 pub fn new(data: String) -> Event {

--- a/src/ssevents/heartbeat.gleam
+++ b/src/ssevents/heartbeat.gleam
@@ -1,13 +1,13 @@
 //// Comment and heartbeat item helpers.
 
-import ssevents/event.{type Item, Comment}
+import ssevents/event.{type Item}
 
 pub const heartbeat_text = "heartbeat"
 
 pub fn comment(text: String) -> Item {
-  Comment(text)
+  event.comment_item(text)
 }
 
 pub fn heartbeat() -> Item {
-  Comment(heartbeat_text)
+  event.comment_item(heartbeat_text)
 }

--- a/src/ssevents/reconnect.gleam
+++ b/src/ssevents/reconnect.gleam
@@ -13,7 +13,7 @@ pub fn new() -> ReconnectState {
 
 pub fn update(state: ReconnectState, item: event.Item) -> ReconnectState {
   case item {
-    event.Comment(_) -> state
+    event.CommentItem(_) -> state
     event.EventItem(ev) ->
       ReconnectState(
         last_event_id: option.or(event.id_of(ev), state.last_event_id),

--- a/test/ssevents/decoder_test.gleam
+++ b/test/ssevents/decoder_test.gleam
@@ -6,7 +6,7 @@ import ssevents
 import ssevents/error.{
   EventTooLarge, InvalidRetry, InvalidUtf8, LineTooLong, TooManyDataLines,
 }
-import ssevents/event.{Comment, EventItem}
+import ssevents/event.{CommentItem, EventItem}
 
 pub fn decode_simple_event_test() {
   let assert Ok([EventItem(event)]) =
@@ -20,7 +20,11 @@ pub fn decode_simple_event_test() {
 
 pub fn decode_comment_and_event_test() {
   let assert Ok(items) = ssevents.decode(": hello\ndata: world\n\n")
-  items |> should.equal([Comment("hello"), EventItem(ssevents.new("world"))])
+  items
+  |> should.equal([
+    CommentItem(event.comment("hello")),
+    EventItem(ssevents.new("world")),
+  ])
 }
 
 pub fn decode_bytes_matches_string_decode_test() {
@@ -449,8 +453,8 @@ pub fn decode_comment_preserves_combining_mark_after_leading_space_test() {
   // `decode_comment_text` shares the same trim helper, so the same
   // bug surfaced for comments.
   let wire = ": \u{1B00}note\n\n"
-  let assert Ok([Comment(text)]) = ssevents.decode(wire)
-  text |> should.equal("\u{1B00}note")
+  let assert Ok([CommentItem(c)]) = ssevents.decode(wire)
+  event.comment_text_of(c) |> should.equal("\u{1B00}note")
 }
 
 pub fn decode_id_preserves_combining_mark_after_leading_space_test() {

--- a/test/ssevents/encoder_test.gleam
+++ b/test/ssevents/encoder_test.gleam
@@ -138,37 +138,38 @@ pub fn encode_normalises_isolated_cr_test() {
 pub fn encode_comment_strips_lf_to_keep_round_trip_test() {
   // Regression for #61: previously `Comment("a\nb")` encoded to
   // `: a\n: b\n` and decoded back to two separate `Comment`
-  // values. Stripping CR / LF inside the comment text keeps the
-  // decoder yielding a single `Comment` — same posture
-  // `sanitize_field_value` takes for `event:` and `id:`.
-  let item = event.Comment("a\nb")
+  // values. Sanitisation now lives at construction (#68), so the
+  // encoder writes a single `:` line and decode returns one
+  // `Comment` matching the sanitised text.
+  let item = event.CommentItem(event.comment("a\nb"))
   let wire = ssevents.encode_item(item)
   let assert Ok(decoded) = ssevents.decode(wire)
-  decoded |> should.equal([event.Comment("ab")])
+  decoded |> should.equal([event.CommentItem(event.comment("ab"))])
 }
 
 pub fn encode_comment_strips_cr_test() {
-  let item = event.Comment("a\rb")
+  let item = event.CommentItem(event.comment("a\rb"))
   let wire = ssevents.encode_item(item)
   let assert Ok(decoded) = ssevents.decode(wire)
-  decoded |> should.equal([event.Comment("ab")])
+  decoded |> should.equal([event.CommentItem(event.comment("ab"))])
 }
 
 pub fn encode_comment_strips_crlf_pair_test() {
-  let item = event.Comment("a\r\nb")
+  let item = event.CommentItem(event.comment("a\r\nb"))
   let wire = ssevents.encode_item(item)
   let assert Ok(decoded) = ssevents.decode(wire)
-  decoded |> should.equal([event.Comment("ab")])
+  decoded |> should.equal([event.CommentItem(event.comment("ab"))])
 }
 
 pub fn encode_comment_round_trips_to_single_comment_test() {
-  // After stripping the encoded wire is exactly one `:` line, so
+  // After sanitisation the encoded wire is exactly one `:` line, so
   // decode returns exactly one `Comment` matching the sanitised
   // input.
-  let item = event.Comment("multi\nline\rdiagnostic")
+  let item = event.CommentItem(event.comment("multi\nline\rdiagnostic"))
   let wire = ssevents.encode_item(item)
   let assert Ok(decoded) = ssevents.decode(wire)
-  decoded |> should.equal([event.Comment("multilinediagnostic")])
+  decoded
+  |> should.equal([event.CommentItem(event.comment("multilinediagnostic"))])
 }
 
 fn contains_byte(input: BitArray, target: Int) -> Bool {

--- a/test/ssevents/parity_test.gleam
+++ b/test/ssevents/parity_test.gleam
@@ -61,7 +61,7 @@ import gleam/string
 import gleeunit/should
 import ssevents
 import ssevents/encoder
-import ssevents/event.{Comment, EventItem}
+import ssevents/event.{CommentItem, EventItem}
 
 // ====== Corpus =============================================================
 
@@ -258,7 +258,7 @@ pub fn roundtrip_single_event_test() {
         let assert Ok(decoded) = ssevents.decode(ssevents.encode(e))
         decoded |> should.equal([EventItem(e)])
       }
-      Comment(_) -> Nil
+      CommentItem(_) -> Nil
     }
   })
 }
@@ -270,7 +270,7 @@ pub fn encode_bytes_equals_from_string_for_event_test() {
       EventItem(e) ->
         ssevents.encode_bytes(e)
         |> should.equal(bit_array.from_string(ssevents.encode(e)))
-      Comment(_) -> Nil
+      CommentItem(_) -> Nil
     }
   })
 }
@@ -279,8 +279,8 @@ pub fn encode_bytes_equals_from_string_for_event_test() {
 // Backs the corpus-level assumption used by (I4).
 pub fn comment_only_roundtrip_test() {
   let assert Ok(decoded) =
-    ssevents.decode(ssevents.encode_item(Comment("hello")))
-  decoded |> should.equal([Comment("hello")])
+    ssevents.decode(ssevents.encode_item(CommentItem(event.comment("hello"))))
+  decoded |> should.equal([CommentItem(event.comment("hello"))])
 }
 
 // ====== Group B: Chunk-boundary parity (parameterised) ====================

--- a/test/ssevents/parity_test.gleam
+++ b/test/ssevents/parity_test.gleam
@@ -283,6 +283,37 @@ pub fn comment_only_roundtrip_test() {
   decoded |> should.equal([CommentItem(event.comment("hello"))])
 }
 
+// Round-trip property for #68: for every input the smart constructor
+// accepts, `decode(encode([CommentItem(comment(s))])) ==
+// [CommentItem(comment(s))]`. Construction-time sanitisation strips
+// CR / LF / NUL, so the decoded comment compares equal to the
+// re-sanitised input — even when the caller's raw string carried
+// line breaks or NUL bytes.
+pub fn comment_round_trip_property_corpus_test() {
+  list.each(
+    [
+      "",
+      "hello",
+      "hello world",
+      "with \u{1F600} emoji",
+      "with newline\nin middle",
+      "with CR\rin middle",
+      "with CRLF\r\nin middle",
+      "with NUL\u{0000}in middle",
+      "leading newline\n",
+      "\nleading newline",
+      "all\rline\nseparators\r\nmixed",
+      "ASCII only — keep verbatim",
+      "日本語のコメント",
+    ],
+    fn(raw) {
+      let item = CommentItem(event.comment(raw))
+      let assert Ok(decoded) = ssevents.decode(ssevents.encode_item(item))
+      decoded |> should.equal([item])
+    },
+  )
+}
+
 // ====== Group B: Chunk-boundary parity (parameterised) ====================
 
 // (I6) Chunked decode equals one-shot decode for several chunk sizes.

--- a/test/ssevents/stream_test.gleam
+++ b/test/ssevents/stream_test.gleam
@@ -2,7 +2,7 @@ import gleam/bit_array
 import gleam/list
 import gleeunit/should
 import ssevents
-import ssevents/event.{Comment, EventItem}
+import ssevents/event.{CommentItem, EventItem}
 import ssevents/stream
 
 pub fn stream_encode_stream_test() {
@@ -25,5 +25,8 @@ pub fn stream_decode_stream_test() {
   chunks
   |> ssevents.decode_stream
   |> stream.to_list
-  |> should.equal([Ok(Comment("hi")), Ok(EventItem(ssevents.new("x")))])
+  |> should.equal([
+    Ok(CommentItem(event.comment("hi"))),
+    Ok(EventItem(ssevents.new("x"))),
+  ])
 }


### PR DESCRIPTION
## Summary

`Item` previously had two transparent variants: `EventItem(Event)`
and `Comment(String)`. `Event` was opaque and went through a
construction-time sanitiser, but `Comment` did not — it accepted any
`String`, and the encoder strip-stripped CR / LF / NUL at the wire
boundary. The result was that `decode(encode([Comment("a\nb")]))`
returned `[Comment("ab")]`, violating the round-trip law for any
caller-built `Item`. Issue #68 asked for the same opaque-+-smart-
constructor treatment that `Event` already had. This PR delivers
that and renames the variant to `CommentItem(Comment)` per the
issue's acceptance criteria.

## Changes

- `src/ssevents/event.gleam`:
  - New `pub opaque type Comment` carrying a sanitised `text`
    field.
  - `Item` variants are now `EventItem(Event)` /
    `CommentItem(Comment)` (renamed from `Comment(String)`).
  - `event.comment(text) -> Comment` smart constructor strips CR,
    LF, and NUL via the existing `sanitize_field_value` helper.
  - `event.comment_text_of(c) -> String` accessor.
  - `event.comment_item(text) -> Item` convenience helper for the
    two-step `CommentItem(comment(text))`.
- `src/ssevents/encoder.gleam`: the wire writer now relies on the
  construction-time invariant that comment text contains no line
  breaks; the previous `strip_line_breaks` workaround (#61) is
  removed.
- `src/ssevents/decoder.gleam`: comment lines are constructed via
  `event.comment` so the round-trip is closed at the boundary.
- `src/ssevents/heartbeat.gleam`, `src/ssevents/reconnect.gleam`:
  use the new variant / constructor.
- Tests (`test/ssevents/decoder_test.gleam`,
  `test/ssevents/encoder_test.gleam`, `test/ssevents/parity_test.gleam`,
  `test/ssevents/stream_test.gleam`): pattern matches and
  constructions migrated to the new shape.
- Examples (`quick_start`, `streaming_consume`): pattern matches
  migrated.
- `CHANGELOG.md`: `[Unreleased] / Changed (BREAKING)` entry with the
  full migration notes.

## Design Decisions

- **Variant renamed, not just made opaque.** Issue #68's acceptance
  criteria called for `EventItem(Event)` / `CommentItem(Comment)`
  with a renamed variant — the symmetry between `EventItem` and
  `CommentItem` reads better than `EventItem` paired with a
  `Comment(_)` variant. The rename is a hard breaking change but
  Gleam's compiler catches every call site, so the migration is
  mechanical.
- **Sanitiser shared with `event_name` / `id`.** Reusing
  `sanitize_field_value` (CR / LF / CRLF / NUL strip) keeps
  comment, name, and id sanitisation in one place. Comments stay a
  single `:` line; LF is dropped entirely because §9.2.6 has no
  notion of a multi-line comment (different from `data`, where LF
  is preserved as a logical newline).
- **Encoder simplified, not duplicated.** Removing the
  `strip_line_breaks` helper at the encoder side means the
  invariant is enforced in exactly one place. A future
  `unchecked_new`-style escape hatch (analogous to
  `multipartkit/part.unchecked_new` from #28) could let internal
  callers bypass sanitisation if needed without re-introducing the
  encoder-side workaround.
- **Public-API helper `ssevents.comment(text)` unchanged.** The
  facade still returns an `Item`, so users of the recommended
  helper see no migration cost. Only callers reaching directly for
  `event.Comment(...)` need to update.

## Limitations

- This is a **breaking change** to the `Item` variant tag and
  the `Comment` constructor. The CHANGELOG entry calls out the
  migration explicitly. Issue #68's acceptance criterion #6 was
  "Decoder paths use `event.comment(...)` to construct `Comment`
  values" — that criterion is met, and the round-trip law for any
  caller-built `Item` (criteria #7) is now closed by construction.

Closes #68


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Comment type is now opaque with smart-constructor and accessor APIs for safer handling.
  * Added convenience wrapper to simplify comment item creation.

* **Changed (BREAKING)**
  * Comment representation changed; migrate using new helper functions for construction and text extraction.
  * Comment sanitization (CR/LF/NUL stripping) now occurs at construction time.

* **Documentation**
  * Updated changelog with migration guidance and API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->