### PR TITLE
chore(release): prepare v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-07
+
 ### Changed (BREAKING)
 - **`Comment` is now an opaque type** in `ssevents/event` and the
   `Item` variant is renamed `Comment(String)` → `CommentItem(Comment)`.

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "ssevents"
-version = "0.7.0"
+version = "0.8.0"
 description = "Server-Sent Events primitives for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "ssevents" }


### PR DESCRIPTION
### Changed (BREAKING)
- **`Comment` is now an opaque type** in `ssevents/event` and the
  `Item` variant is renamed `Comment(String)` → `CommentItem(Comment)`.
  Construct a `Comment` via the new smart constructor
  `event.comment(text: String) -> Comment`, which strips CR / LF /
  NUL at construction (the same posture taken for `event_name` and
  `id` — comments cannot be multi-line per WHATWG SSE §9.2.6, so
  unlike `data` no LF is preserved). Inspect with
  `event.comment_text_of(c) -> String`. The convenience
  `event.comment_item(text)` wraps the two-step
  `CommentItem(comment(text))`.

  Why: WHATWG SSE §9.2.6 has no notion of a multi-line comment, so
  any embedded line break in a `Comment` value would fan out to
  multiple `:` lines on the wire and the decoder would surface them
  as separate `Comment` items — breaking
  `decode(encode([CommentItem(c)])) == [CommentItem(c)]`. Closing
  the round-trip law at construction is the same fix shape as #67
  for `Event.data`. The `encode_item` / `decode` paths now rely on
  the construction-time invariant; the encoder no longer needs the
  `strip_line_breaks` workaround that #61 introduced.

  Migration:
  - `event.Comment(text)` constructor → `event.comment(text)` (or
    `event.comment_item(text)` if you immediately want an `Item`).
  - Pattern match `event.Comment(text)` → `event.CommentItem(c)`
    plus `let text = event.comment_text_of(c)`.

  The facade helper `ssevents.comment(text)` is unchanged on the
  surface — it still returns an `Item`, matching the previous
  behaviour. Built-in examples (`quick_start`, `streaming_consume`)
  and tests are updated. (#68)

### Fixed
- **`event.new`, `event.from_parts`, and `event.data` now sanitise
  the `data` value at construction**: CR (U+000D) and NUL (U+0000)
  are stripped, and a CRLF grapheme is normalised to a single LF.
  LF is preserved as a logical line separator (the encoder splits
  on LF to emit multi-line `data:` blocks; the decoder rejoins them
  with LF). Previously the in-memory `data` carried whatever bytes
  the caller passed, but the encoder ran them through
  `normalise_newlines` on the way to the wire — so an `Event` with
  `data = "a\r\nb"` round-tripped to an `Event` with `data = "a\nb"`,
  violating the round-trip guarantee documented in
  `event.gleam`'s top comment. Construction now matches the wire
  shape, closing the round-trip law for any caller-built `Event`.
  Matches the `sanitize_field_value` posture already used for
  `event_name` and `id` (silent strip, not a `Result`-returning
  builder). The `encode_normalises_lone_cr_between_lf_pair_test`
  regression test from #58 stays in place but now relies on the
  construction-time sanitiser to keep CR off the wire. (#67)
