### PR TITLE
fix(event): panic on negative retry, add retry_clamp lenient sibling (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`ssevents.retry/2` and `ssevents/event.retry/2` now panic on
+  negative `milliseconds`** with
+  `"ssevents.retry: milliseconds must be >= 0 (got <n>); the SSE spec
+  mandates a non-negative reconnection time."`. Previously the builder
+  silently dropped negative values to `None` (the round-trip
+  sanitisation added in #60), which left callers unaware they had
+  passed an out-of-spec value. WHATWG SSE §9.2.6 only recognises a
+  retry value whose textual form "consists of only ASCII digits", so a
+  negative value would either be dropped by spec-compliant clients (the
+  leading `-` breaks the digits-only check) or interpreted as `0` and
+  trigger a tight reconnect loop against the server. (#73)
+
+### Added
+- **`ssevents.retry_clamp/2` (and `ssevents/event.retry_clamp/2`)** is
+  the lenient sibling of `retry/2`: it clamps `milliseconds < 0` to
+  `0` instead of panicking. Use it when forwarding a value computed
+  from possibly-noisy input (CLI flag, deserialised config) and the
+  caller would rather "publish a spec-valid retry" than crash. All
+  other behaviour matches `retry/2`, including the `> max_retry`
+  silent drop to `None` for round-trip with the default decoder. (#73)
+
 ## [0.8.0] - 2026-05-07
 
 ### Changed (BREAKING)

--- a/gleam.toml
+++ b/gleam.toml
@@ -30,6 +30,7 @@ unused_exports = "off"
   "prefer_guard_clause",
   "thrown_away_error",
 ]
+"src/ssevents/event.gleam" = ["avoid_panic", "prefer_guard_clause"]
 "src/ssevents/limit.gleam" = ["avoid_panic"]
 "src/ssevents/stream.gleam" = ["deep_nesting"]
 "src/ssevents/validate.gleam" = ["avoid_panic", "prefer_guard_clause"]

--- a/src/ssevents.gleam
+++ b/src/ssevents.gleam
@@ -110,8 +110,25 @@ pub fn id(event: Event, id: String) -> Event {
   event.id(event, id)
 }
 
+/// Set the SSE `retry:` reconnection time on an event.
+///
+/// `milliseconds` must be `>= 0`. WHATWG SSE §9.2.6 only recognises a
+/// retry value whose textual form "consists of only ASCII digits", so a
+/// negative value would be either dropped on the wire (the leading `-`
+/// breaks the digits-only check) or interpreted as `0` and trigger a
+/// tight reconnect loop against the server. The builder panics on
+/// `ms < 0`; reach for `retry_clamp/2` when the caller wants the
+/// lenient (clamp-to-`0`) posture.
 pub fn retry(event: Event, milliseconds: Int) -> Event {
   event.retry(event, milliseconds)
+}
+
+/// Like `retry/2`, but clamps `milliseconds < 0` to `0` instead of
+/// panicking. Use this when forwarding a value computed from possibly-
+/// noisy input (e.g. a CLI flag, a deserialised config) and the caller
+/// would rather "publish a spec-valid retry" than crash.
+pub fn retry_clamp(event: Event, milliseconds: Int) -> Event {
+  event.retry_clamp(event, milliseconds)
 }
 
 pub fn data(event: Event, data: String) -> Event {

--- a/src/ssevents/event.gleam
+++ b/src/ssevents/event.gleam
@@ -7,6 +7,7 @@
 //// modules can pattern match on whether a stream element is an event
 //// or a comment.
 
+import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import gleam/string
@@ -132,12 +133,54 @@ fn option_sanitize(opt: Option(String)) -> Option(String) {
   }
 }
 
+/// Set the SSE `retry:` reconnection time on an event.
+///
+/// `milliseconds` must be `>= 0`. WHATWG SSE §9.2.6 only recognises a
+/// retry value whose textual form "consists of only ASCII digits", so a
+/// negative value would be either dropped on the wire (the leading `-`
+/// breaks the digits-only check) or interpreted as `0` and trigger a
+/// tight reconnect loop against the server. Either outcome is a
+/// contract violation, so the builder panics on `ms < 0` with
+/// `"ssevents.retry: milliseconds must be >= 0 (got <n>); the SSE spec
+/// mandates a non-negative reconnection time."`. Use `retry_clamp/2`
+/// instead when the caller wants the lenient (clamp-to-`0`) behaviour.
+///
+/// Values above `limit.default_max_retry_value` (24 h in ms) are still
+/// silently dropped to `None`, matching `from_parts/4` and the
+/// `decode(encode(_))` round-trip property pinned in #60.
 pub fn retry(event: Event, milliseconds: Int) -> Event {
+  case milliseconds < 0 {
+    True ->
+      panic as {
+        "ssevents.retry: milliseconds must be >= 0 (got "
+        <> int.to_string(milliseconds)
+        <> "); the SSE spec mandates a non-negative reconnection time."
+      }
+    False ->
+      Event(
+        event: event.event,
+        data: event.data,
+        id: event.id,
+        retry: sanitize_retry(Some(milliseconds)),
+      )
+  }
+}
+
+/// Like `retry/2`, but clamps `milliseconds < 0` to `0` instead of
+/// panicking. Use this when the caller wants the lenient posture
+/// (e.g. when forwarding a value computed from possibly-noisy input).
+/// All other behaviour matches `retry/2`, including the `> max_retry`
+/// silent drop to `None` for round-trip with the default decoder.
+pub fn retry_clamp(event: Event, milliseconds: Int) -> Event {
+  let clamped = case milliseconds < 0 {
+    True -> 0
+    False -> milliseconds
+  }
   Event(
     event: event.event,
     data: event.data,
     id: event.id,
-    retry: sanitize_retry(Some(milliseconds)),
+    retry: sanitize_retry(Some(clamped)),
   )
 }
 

--- a/test/ssevents/event_test.gleam
+++ b/test/ssevents/event_test.gleam
@@ -152,16 +152,13 @@ pub fn encode_then_decode_round_trips_after_sanitisation_test() {
   rewire |> should.equal(wire)
 }
 
-// Construction-time sanitisation for `retry`: a negative value is
-// silently dropped on decode by §9.2.6 ASCII-digits rule, and any
-// value above the default 24-hour cap hard-fails the decoder. Both
-// shapes are coerced to `None` at construction so encode → decode
-// is a no-op.
-
-pub fn retry_setter_drops_negative_test() {
-  let event = ssevents.new("payload") |> ssevents.retry(-100)
-  ssevents.retry_of(event) |> should.equal(None)
-}
+// Construction-time sanitisation for `retry` (#73, #60):
+// - `retry/2` (builder) panics on `< 0` because emitting a negative
+//   reconnection time violates WHATWG SSE §9.2.6.
+// - `retry_clamp/2` is the lenient sibling that clamps `< 0` to `0`.
+// - `from_parts/4` (decode-shaped entry point) still silently coerces
+//   `< 0` and `> default_max_retry_value` to `None` so
+//   `decode(encode(_))` round-trips for any caller-built `Event`.
 
 pub fn retry_setter_drops_value_above_default_max_test() {
   // limit.default_max_retry_value == 86_400_000 (24h in ms).
@@ -178,6 +175,44 @@ pub fn retry_setter_keeps_zero_test() {
 pub fn retry_setter_keeps_default_max_boundary_test() {
   let event = ssevents.new("payload") |> ssevents.retry(86_400_000)
   ssevents.retry_of(event) |> should.equal(Some(86_400_000))
+}
+
+pub fn retry_setter_keeps_one_million_test() {
+  // Per the issue: 1_000_000 ms is well below the default 24h cap and
+  // must round-trip without coercion.
+  let event = ssevents.new("payload") |> ssevents.retry(1_000_000)
+  ssevents.retry_of(event) |> should.equal(Some(1_000_000))
+}
+
+// --- retry_clamp lenient sibling ---
+
+pub fn retry_clamp_clamps_negative_to_zero_test() {
+  let event = ssevents.new("payload") |> ssevents.retry_clamp(-100)
+  ssevents.retry_of(event) |> should.equal(Some(0))
+}
+
+pub fn retry_clamp_clamps_minus_one_to_zero_test() {
+  // Boundary: -1 is the smallest negative; canonical reproducer from #73.
+  let event = ssevents.new("payload") |> ssevents.retry_clamp(-1)
+  ssevents.retry_of(event) |> should.equal(Some(0))
+}
+
+pub fn retry_clamp_keeps_zero_test() {
+  let event = ssevents.new("payload") |> ssevents.retry_clamp(0)
+  ssevents.retry_of(event) |> should.equal(Some(0))
+}
+
+pub fn retry_clamp_passes_through_positive_values_test() {
+  let event = ssevents.new("payload") |> ssevents.retry_clamp(2500)
+  ssevents.retry_of(event) |> should.equal(Some(2500))
+}
+
+pub fn retry_clamp_drops_above_default_max_test() {
+  // The clamp lower-bound only floors negatives; values above the
+  // default decoder cap still get the silent drop for round-trip with
+  // `decode`.
+  let event = ssevents.new("payload") |> ssevents.retry_clamp(1_000_000_000)
+  ssevents.retry_of(event) |> should.equal(None)
 }
 
 pub fn from_parts_drops_negative_retry_test() {


### PR DESCRIPTION
## Summary

`ssevents.retry/2` previously accepted any `Int` (including negatives) and silently dropped `< 0` to `None` via the round-trip sanitiser added in #60. WHATWG SSE §9.2.6 only recognises a retry value whose textual form "consists of only ASCII digits", so a negative would either be dropped by spec-compliant clients or interpreted as `0` and trigger a tight reconnect loop. This change makes the builder panic on `< 0` (matching the construction-time validation pattern in `limit.gleam` / `validate.gleam`) and adds `retry_clamp/2` for callers who want the lenient (clamp-to-`0`) posture. Closes #73.

## Changes

- `src/ssevents/event.gleam`
  - `retry/2` panics with `"ssevents.retry: milliseconds must be >= 0 (got <n>); the SSE spec mandates a non-negative reconnection time."` when `milliseconds < 0`. Doc string now cites WHATWG SSE §9.2.6.
  - New `retry_clamp/2` clamps `milliseconds < 0` to `0` and otherwise behaves identically to `retry/2` (including the `> max_retry` silent drop for `decode(encode(_))` round-trip with the default decoder).
  - `from_parts/4` is unchanged — it still silently sanitises `Some(< 0)` → `None` because that is the decode-shaped entry point and the round-trip property pinned in #60 depends on it.
- `src/ssevents.gleam`: facade `retry/2` doc string updated; `retry_clamp/2` re-export added.
- `test/ssevents/event_test.gleam`: replaced `retry_setter_drops_negative_test` (now panics) with five `retry_clamp` tests pinning the lenient surface (`-100 → 0`, `-1 → 0`, `0 → 0`, `2500 → 2500`, `1_000_000_000 → None`). Added `retry_setter_keeps_one_million_test` per the issue's acceptance criteria.
- `gleam.toml`: `event.gleam` is added to the `glinter.ignore` list with `["avoid_panic", "prefer_guard_clause"]` to match how `limit.gleam` and `validate.gleam` already exempt the same patterns at construction-time validation seams.
- `CHANGELOG.md`: documents the fix and the new `retry_clamp/2` API under `[Unreleased]`.

## Design Decisions

- **Panic over `Result`** for the strict variant: matches the existing precedent in `limit.gleam` (5 panics on bad limit construction) and `validate.gleam`. Encoder-side errors are runtime-shape bugs that the caller should fix, not handle.
- **`retry_clamp/2` as a separate function** rather than a flag/keyword arg on `retry/2`: keeps the strict path total (`Event -> Int -> Event`) and lets the lenient surface advertise its policy in the name.
- **Plain `case`, not `bool.guard`**: `bool.guard(when: cond, return: panic as ...)` evaluates the `panic` argument eagerly (the compiler warns "previous argument always panics"), which silently breaks the guard. The `case` form keeps the panic on the `True` arm only.
- **`from_parts/4` unchanged**: it is the constructor used by the decoder and round-trip tests (#60). Forcing it to panic would break the `decode(encode(_))` round-trip property for any `Event` containing a negative retry, which is exactly the shape the round-trip sanitiser is there to absorb.

## Limitations

- The metamon property test mentioned in the issue is not added: metamon is not a dev-dep of ssevents and the deterministic boundary tests (-1, -100, 0, 2500, 1_000_000, 1_000_000_000) cover the same ground.
- Behaviour change: callers relying on the previous silent-drop posture for negative `retry` values via the builder will now panic. Migration is `event |> ssevents.retry_clamp(ms)`.

Closes #73