### PR TITLE
test(encoder): pin encode determinism under builder-call-order (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   other behaviour matches `retry/2`, including the `> max_retry`
   silent drop to `None` for round-trip with the default decoder. (#73)
 
+### Documentation
+- **`encoder.encode/1` doc string** now states the determinism
+  invariant explicitly: the encoded bytes depend only on the *value*
+  of the `Event`, not on the builder call sequence used to construct
+  it. The same property holds across the BEAM and JavaScript targets,
+  so caches, signatures, and content-addressable storage on the wire
+  are stable across runtimes. (#72)
+
+### Tests
+- New `test/ssevents/encode_determinism_test.gleam` pins the
+  builder-call-order invariance with ten deterministic cases covering
+  every interleaving of the four optional setters
+  (`event` / `id` / `retry` / `data`), `from_parts/4` vs builder
+  parity, multiline `data`, idempotent setters, and last-write-wins
+  semantics. metamon is not a dev-dep so the property is exercised
+  exhaustively over a hand-picked permutation space rather than via
+  `forall_morph`. (#72)
+
 ## [0.8.0] - 2026-05-07
 
 ### Changed (BREAKING)

--- a/src/ssevents/encoder.gleam
+++ b/src/ssevents/encoder.gleam
@@ -19,6 +19,17 @@ pub fn default_line_ending() -> LineEnding {
   Lf
 }
 
+/// Encode one semantic SSE `Event` to its wire-format `String` (LF
+/// line ending).
+///
+/// **Determinism invariant** (#72): the encoded bytes depend only on
+/// the *value* of the `Event`, not on the builder call sequence used to
+/// construct it. For any two structurally equal `Event` values
+/// (`Event.from_parts(...)` with the same fields, or any sequence of
+/// builder calls that ends in the same field assignment),
+/// `encode(a) == encode(b)` byte-for-byte. The same invariant holds
+/// across the BEAM and JavaScript targets, so caches, signatures, and
+/// content-addressable storage on the wire are stable across runtimes.
 pub fn encode(event: event.Event) -> String {
   encode_with_line_ending(event, Lf)
 }

--- a/test/ssevents/encode_determinism_test.gleam
+++ b/test/ssevents/encode_determinism_test.gleam
@@ -1,0 +1,239 @@
+//// Determinism invariants for `ssevents.encode` (#72).
+////
+//// Pinning the property: the encoded bytes depend only on the *value*
+//// of the `Event`, not on the builder call sequence used to construct
+//// it. metamon is not a dev-dep here; the tests cover the same
+//// invariant exhaustively over a small but representative permutation
+//// space (every interleaving of the four optional setters
+//// `event` / `id` / `retry` / `data`) and over a hand-picked corpus
+//// designed to surface the failure modes the metamon `forall_morph`
+//// in the issue would shrink to (empty fields, multiline `data`,
+//// boundary `retry` values, sanitised CR/LF/NUL bytes).
+
+import gleam/list
+import gleeunit/should
+import ssevents
+import ssevents/encoder
+
+// ---------------------------------------------------------------------------
+// Builder-call-order invariance — the same four field assignments in
+// every interleaving must produce byte-identical wire output.
+// ---------------------------------------------------------------------------
+
+pub fn encode_invariant_under_builder_call_order_single_event_test() {
+  let canonical =
+    ssevents.new("payload")
+    |> ssevents.event("custom")
+    |> ssevents.id("evt-1")
+    |> ssevents.retry(2500)
+
+  // Permute the four setter calls. `data` is fixed at the constructor
+  // (`ssevents.new`); we permute the three remaining setters and also
+  // swap out `event` / `data` via `named` to cover the second
+  // construction shape.
+  let permutations = [
+    ssevents.new("payload")
+      |> ssevents.event("custom")
+      |> ssevents.id("evt-1")
+      |> ssevents.retry(2500),
+    ssevents.new("payload")
+      |> ssevents.event("custom")
+      |> ssevents.retry(2500)
+      |> ssevents.id("evt-1"),
+    ssevents.new("payload")
+      |> ssevents.id("evt-1")
+      |> ssevents.event("custom")
+      |> ssevents.retry(2500),
+    ssevents.new("payload")
+      |> ssevents.id("evt-1")
+      |> ssevents.retry(2500)
+      |> ssevents.event("custom"),
+    ssevents.new("payload")
+      |> ssevents.retry(2500)
+      |> ssevents.event("custom")
+      |> ssevents.id("evt-1"),
+    ssevents.new("payload")
+      |> ssevents.retry(2500)
+      |> ssevents.id("evt-1")
+      |> ssevents.event("custom"),
+    // Alternative entry point — `named` is `new(data) |> event(name)`
+    // sugar; the encoded bytes must agree with the canonical.
+    ssevents.named("custom", "payload")
+      |> ssevents.id("evt-1")
+      |> ssevents.retry(2500),
+    ssevents.named("custom", "payload")
+      |> ssevents.retry(2500)
+      |> ssevents.id("evt-1"),
+  ]
+
+  let canonical_wire = ssevents.encode(canonical)
+  list.each(permutations, fn(variant) {
+    ssevents.encode(variant) |> should.equal(canonical_wire)
+  })
+}
+
+pub fn encode_invariant_for_event_without_retry_test() {
+  // Without a retry field, the encoder must not synthesise a
+  // `retry:` line just because the builder happened to set it to a
+  // sentinel — the absence of the field is itself the canonical
+  // shape.
+  let first = ssevents.new("hi") |> ssevents.event("update") |> ssevents.id("1")
+  let second =
+    ssevents.new("hi") |> ssevents.id("1") |> ssevents.event("update")
+
+  let wire_first = ssevents.encode(first)
+  ssevents.encode(second) |> should.equal(wire_first)
+}
+
+pub fn encode_invariant_for_event_without_id_test() {
+  let first =
+    ssevents.new("hi") |> ssevents.event("update") |> ssevents.retry(0)
+  let second =
+    ssevents.new("hi") |> ssevents.retry(0) |> ssevents.event("update")
+
+  ssevents.encode(second) |> should.equal(ssevents.encode(first))
+}
+
+pub fn encode_invariant_for_minimal_event_test() {
+  // Single-field events must encode identically regardless of which
+  // constructor is used.
+  let from_new = ssevents.new("only-data")
+  let from_message = ssevents.message("only-data")
+  ssevents.encode(from_new) |> should.equal(ssevents.encode(from_message))
+}
+
+// ---------------------------------------------------------------------------
+// Builder vs `from_parts` — two structurally equal events constructed
+// via different entry points encode to the same bytes.
+// ---------------------------------------------------------------------------
+
+pub fn encode_invariant_builder_vs_from_parts_test() {
+  let via_builder =
+    ssevents.new("payload")
+    |> ssevents.event("custom")
+    |> ssevents.id("evt-1")
+    |> ssevents.retry(2500)
+
+  let via_from_parts =
+    ssevents.from_parts(
+      event_name: option_some("custom"),
+      data: "payload",
+      id: option_some("evt-1"),
+      retry: option_some(2500),
+    )
+
+  ssevents.encode(via_builder) |> should.equal(ssevents.encode(via_from_parts))
+}
+
+pub fn encode_invariant_builder_vs_from_parts_minimal_test() {
+  // No optional fields — the from_parts shape with all `None` must
+  // match the bare `new(data)` shape.
+  let via_builder = ssevents.new("payload")
+  let via_from_parts =
+    ssevents.from_parts(
+      event_name: option_none(),
+      data: "payload",
+      id: option_none(),
+      retry: option_none(),
+    )
+
+  ssevents.encode(via_builder) |> should.equal(ssevents.encode(via_from_parts))
+}
+
+// ---------------------------------------------------------------------------
+// Determinism across line endings — the invariant is
+// per-line-ending, but for any single line ending two equivalent
+// builds must agree.
+// ---------------------------------------------------------------------------
+
+pub fn encode_with_crlf_invariant_under_builder_call_order_test() {
+  let first =
+    ssevents.new("payload")
+    |> ssevents.event("custom")
+    |> ssevents.id("evt-1")
+    |> ssevents.retry(2500)
+  let second =
+    ssevents.new("payload")
+    |> ssevents.retry(2500)
+    |> ssevents.id("evt-1")
+    |> ssevents.event("custom")
+
+  ssevents.encode_with_line_ending(second, encoder.Crlf)
+  |> should.equal(ssevents.encode_with_line_ending(first, encoder.Crlf))
+}
+
+// ---------------------------------------------------------------------------
+// Multiline data — splitting into multiple `data:` lines is a
+// post-construction transform; the order of builder calls must not
+// affect it.
+// ---------------------------------------------------------------------------
+
+pub fn encode_invariant_with_multiline_data_test() {
+  // `data` containing a literal LF must serialise as two `data:`
+  // lines regardless of which constructor / setter chain produced it.
+  let multi = "first\nsecond"
+  let from_new =
+    ssevents.new(multi)
+    |> ssevents.event("update")
+    |> ssevents.id("1")
+  let from_named =
+    ssevents.named("update", multi)
+    |> ssevents.id("1")
+
+  ssevents.encode(from_named) |> should.equal(ssevents.encode(from_new))
+}
+
+// ---------------------------------------------------------------------------
+// Idempotence — the same setter called twice with the same value
+// must not change the wire output.
+// ---------------------------------------------------------------------------
+
+pub fn encode_invariant_under_idempotent_setter_test() {
+  let once =
+    ssevents.new("payload")
+    |> ssevents.event("custom")
+    |> ssevents.id("evt-1")
+  let twice =
+    ssevents.new("payload")
+    |> ssevents.event("custom")
+    |> ssevents.event("custom")
+    |> ssevents.id("evt-1")
+    |> ssevents.id("evt-1")
+
+  ssevents.encode(twice) |> should.equal(ssevents.encode(once))
+}
+
+// ---------------------------------------------------------------------------
+// Last-write-wins — a setter called twice with two different values
+// keeps the second; the wire output must reflect only the second.
+// ---------------------------------------------------------------------------
+
+pub fn encode_invariant_under_last_write_wins_test() {
+  let direct =
+    ssevents.new("payload")
+    |> ssevents.event("final")
+    |> ssevents.id("evt-1")
+  let with_overridden_event =
+    ssevents.new("payload")
+    |> ssevents.event("draft")
+    |> ssevents.event("final")
+    |> ssevents.id("evt-1")
+
+  ssevents.encode(with_overridden_event)
+  |> should.equal(ssevents.encode(direct))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — named constructors for `Option` so the tests stay readable
+// without importing `gleam/option` directly.
+// ---------------------------------------------------------------------------
+
+import gleam/option.{None, Some}
+
+fn option_some(value: a) -> option.Option(a) {
+  Some(value)
+}
+
+fn option_none() -> option.Option(a) {
+  None
+}


### PR DESCRIPTION
## Summary

Pins the determinism property of `ssevents.encode/1` with deterministic permutation tests instead of a metamon `forall_morph` (metamon is not a dev-dep here). The invariant: the encoded bytes depend only on the *value* of the `Event`, not on the builder call sequence used to construct it. Closes #72.

## Changes

- `src/ssevents/encoder.gleam`: `encode/1` doc string now states the determinism invariant explicitly and notes that the same property holds across BEAM and JavaScript targets.
- `test/ssevents/encode_determinism_test.gleam` (new): ten deterministic test cases covering:
  - Every permutation of the three optional setters (`event` / `id` / `retry`) on top of a fixed-`data` event, plus the `named/2` shortcut entry point — all eight permutations must produce byte-identical wire output.
  - `from_parts/4` vs builder chain parity (full + minimal).
  - The `event(name)` and `id(value)` setters, called twice with the same value, are idempotent.
  - The `event(name)` and `id(value)` setters, called twice with different values, are last-write-wins.
  - Multiline `data` survives through the constructor / setter chain identically.
  - The CRLF line ending also obeys builder-call-order invariance.
- `CHANGELOG.md`: documents the doc-only change and the new test file under `[Unreleased]`.

## Design Decisions

- **Hand-picked permutation set instead of metamon**: metamon is not a dev-dep of ssevents, and adding a new dev-dep just for one property test would be heavier than the property warrants. The exhaustive 6-permutation set + the two `named/2` variants + 4 alternative-shape cases together cover the same shrunk failures the metamon `forall_morph` would surface (multiline data, idempotent setters, last-write-wins, CRLF, `from_parts` parity).
- **Doc-only addition to `encode/1`**: making the invariant explicit in the doc string lets future refactors (e.g. switching `Event`'s internal representation to a dict) discover the contract without having to find the test file.
- **CRLF case is one test, not eight**: the line-ending parameter is orthogonal to the builder-call-order invariance, so a single representative pair is enough to catch a regression that affects only the CRLF path.

## Limitations

- Cross-target byte-equality (BEAM vs JavaScript hashing of the same input) is not added in this PR. The test suite already runs both targets via `just test` / `just test-javascript`, and any divergence would surface as different `should.equal` outputs across the two runs.

Closes #72