### PR TITLE
chore(release): prepare v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-05-08
+
 ### Fixed
 - **`ssevents.retry/2` and `ssevents/event.retry/2` now panic on
   negative `milliseconds`** with

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "ssevents"
-version = "0.8.0"
+version = "0.9.0"
 description = "Server-Sent Events primitives for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "ssevents" }


### PR DESCRIPTION
### Fixed
- **`ssevents.retry/2` and `ssevents/event.retry/2` now panic on
  negative `milliseconds`** with
  `"ssevents.retry: milliseconds must be >= 0 (got <n>); the SSE spec
  mandates a non-negative reconnection time."`. Previously the builder
  silently dropped negative values to `None` (the round-trip
  sanitisation added in #60), which left callers unaware they had
  passed an out-of-spec value. WHATWG SSE §9.2.6 only recognises a
  retry value whose textual form "consists of only ASCII digits", so a
  negative value would either be dropped by spec-compliant clients (the
  leading `-` breaks the digits-only check) or interpreted as `0` and
  trigger a tight reconnect loop against the server. (#73)

### Added
- **`ssevents.retry_clamp/2` (and `ssevents/event.retry_clamp/2`)** is
  the lenient sibling of `retry/2`: it clamps `milliseconds < 0` to
  `0` instead of panicking. Use it when forwarding a value computed
  from possibly-noisy input (CLI flag, deserialised config) and the
  caller would rather "publish a spec-valid retry" than crash. All
  other behaviour matches `retry/2`, including the `> max_retry`
  silent drop to `None` for round-trip with the default decoder. (#73)

### Documentation
- **`encoder.encode/1` doc string** now states the determinism
  invariant explicitly: the encoded bytes depend only on the *value*
  of the `Event`, not on the builder call sequence used to construct
  it. The same property holds across the BEAM and JavaScript targets,
  so caches, signatures, and content-addressable storage on the wire
  are stable across runtimes. (#72)

### Tests
- New `test/ssevents/encode_determinism_test.gleam` pins the
  builder-call-order invariance with ten deterministic cases covering
  every interleaving of the four optional setters
  (`event` / `id` / `retry` / `data`), `from_parts/4` vs builder
  parity, multiline `data`, idempotent setters, and last-write-wins
  semantics. metamon is not a dev-dep so the property is exercised
  exhaustively over a hand-picked permutation space rather than via
  `forall_morph`. (#72)
