### PR TITLE
feat(facade): add Item-level accessors so decode consumers can stay inside the ssevents module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **Item-level accessors on the top-level `ssevents` facade** so
+  callers that decode an SSE stream can pattern-match (or filter)
+  results without reaching into `ssevents/event` for the
+  `EventItem` / `CommentItem` constructors. Gleam's type aliases do
+  not re-export variant constructors, which forced every `decode`
+  caller to add a second `import ssevents/event.{...}`. The new
+  accessors solve this without breaking the type-alias re-export
+  contract:
+    - `ssevents.is_event(item)` / `ssevents.is_comment(item)` —
+      shape predicates.
+    - `ssevents.event_of_item(item) -> Option(Event)` — extract the
+      event payload, `None` for comments.
+    - `ssevents.comment_text_of_item(item) -> Option(String)` —
+      mirror for the comment side.
+    - `ssevents.events_of(items)` /
+      `ssevents.comment_texts_of(items)` — list-level filter helpers
+      for the common "I just want the events" pattern.
+  (#77)
+
 ## [0.9.0] - 2026-05-08
 
 ### Fixed

--- a/src/ssevents.gleam
+++ b/src/ssevents.gleam
@@ -15,7 +15,8 @@
 //// missing entry point can be added at this level is preferred to
 //// scattering submodule imports across user code.
 
-import gleam/option.{type Option}
+import gleam/list
+import gleam/option.{type Option, None, Some}
 import ssevents/decoder
 import ssevents/encoder
 import ssevents/error
@@ -145,6 +146,59 @@ pub fn comment(text: String) -> Item {
 
 pub fn heartbeat() -> Item {
   heartbeat.heartbeat()
+}
+
+/// Issue #77: Item-level inspection helpers exposed through the
+/// facade. The `Item` type is re-exported as a type alias from this
+/// module, but Gleam's type aliases do not carry the underlying
+/// `EventItem` / `CommentItem` constructors — pattern-matching on a
+/// decoded `Item` therefore requires reaching into
+/// `ssevents/event` for the variants. These accessors let callers stay
+/// inside the facade for the common cases.
+/// `True` when the item is an event (carries an SSE `Event` payload).
+pub fn is_event(item: Item) -> Bool {
+  event.is_event(item)
+}
+
+/// `True` when the item is a `:`-prefixed comment line.
+pub fn is_comment(item: Item) -> Bool {
+  event.is_comment(item)
+}
+
+/// Return the event payload when the item is an event, `None`
+/// otherwise. Pairs with `comment_text_of_item/1` for the comment
+/// side.
+pub fn event_of_item(item: Item) -> Option(Event) {
+  event.event_of_item(item)
+}
+
+/// Return the comment text when the item is a comment, `None`
+/// otherwise.
+pub fn comment_text_of_item(item: Item) -> Option(String) {
+  event.comment_text_of_item(item)
+}
+
+/// Filter a decoded item list down to its events, dropping comments.
+/// Convenience for the common "I just want the events" pattern after
+/// `decode/1`.
+pub fn events_of(items: List(Item)) -> List(Event) {
+  list.filter_map(items, fn(item) {
+    case event.event_of_item(item) {
+      Some(ev) -> Ok(ev)
+      None -> Error(Nil)
+    }
+  })
+}
+
+/// Filter a decoded item list down to its comment texts, dropping
+/// events. Pairs with `events_of/1`.
+pub fn comment_texts_of(items: List(Item)) -> List(String) {
+  list.filter_map(items, fn(item) {
+    case event.comment_text_of_item(item) {
+      Some(text) -> Ok(text)
+      None -> Error(Nil)
+    }
+  })
 }
 
 pub fn default_line_ending() -> LineEnding {

--- a/src/ssevents/event.gleam
+++ b/src/ssevents/event.gleam
@@ -60,6 +60,48 @@ pub fn comment_item(text: String) -> Item {
   CommentItem(comment(text))
 }
 
+/// Issue #77: Item-level accessors. The `Item` variants `EventItem` /
+/// `CommentItem` are not visible through the top-level `ssevents`
+/// module (a Gleam type alias does not re-export its constructors), so
+/// callers that decode an SSE stream and want to pattern-match on the
+/// result would otherwise need to reach into `ssevents/event` directly.
+/// These helpers let `ssevents`-only callers walk decoded items without
+/// the second import.
+/// `True` when the item is an event (carries an SSE `Event` payload).
+pub fn is_event(item: Item) -> Bool {
+  case item {
+    EventItem(_) -> True
+    CommentItem(_) -> False
+  }
+}
+
+/// `True` when the item is a `:`-prefixed comment line.
+pub fn is_comment(item: Item) -> Bool {
+  case item {
+    CommentItem(_) -> True
+    EventItem(_) -> False
+  }
+}
+
+/// Return the event payload when the item is an event, `None`
+/// otherwise. Use with `option.then` / `case` for stream processing
+/// that ignores comments.
+pub fn event_of_item(item: Item) -> Option(Event) {
+  case item {
+    EventItem(ev) -> Some(ev)
+    CommentItem(_) -> None
+  }
+}
+
+/// Return the comment text when the item is a comment, `None`
+/// otherwise. Mirrors `event_of_item/1` for the comment side.
+pub fn comment_text_of_item(item: Item) -> Option(String) {
+  case item {
+    CommentItem(c) -> Some(comment_text_of(c))
+    EventItem(_) -> None
+  }
+}
+
 pub fn new(data: String) -> Event {
   Event(event: None, data: sanitize_data_value(data), id: None, retry: None)
 }

--- a/test/ssevents/event_test.gleam
+++ b/test/ssevents/event_test.gleam
@@ -263,3 +263,78 @@ pub fn encode_decode_round_trips_after_retry_sanitisation_test() {
   ssevents.encode_item(decoded_huge)
   |> should.equal(ssevents.encode(huge))
 }
+
+// Issue #77: facade-level Item accessors so callers can pattern-match
+// (or filter) on decoded items without reaching into `ssevents/event`.
+
+pub fn is_event_distinguishes_event_and_comment_test() {
+  let ev = ssevents.event_item(ssevents.new("hello"))
+  let cm = ssevents.comment("ping")
+  ssevents.is_event(ev) |> should.equal(True)
+  ssevents.is_event(cm) |> should.equal(False)
+  ssevents.is_comment(ev) |> should.equal(False)
+  ssevents.is_comment(cm) |> should.equal(True)
+}
+
+pub fn event_of_item_returns_event_for_event_item_test() {
+  let underlying = ssevents.new("payload") |> ssevents.event("job.update")
+  let item = ssevents.event_item(underlying)
+  case ssevents.event_of_item(item) {
+    Some(ev) -> ssevents.name_of(ev) |> should.equal(Some("job.update"))
+    None -> should.fail()
+  }
+}
+
+pub fn event_of_item_returns_none_for_comment_test() {
+  ssevents.event_of_item(ssevents.comment("ping"))
+  |> should.equal(None)
+}
+
+pub fn comment_text_of_item_returns_text_for_comment_test() {
+  ssevents.comment_text_of_item(ssevents.comment("ping"))
+  |> should.equal(Some("ping"))
+}
+
+pub fn comment_text_of_item_returns_none_for_event_test() {
+  let item = ssevents.event_item(ssevents.new("payload"))
+  ssevents.comment_text_of_item(item) |> should.equal(None)
+}
+
+pub fn events_of_filters_to_event_payloads_test() {
+  let items = [
+    ssevents.event_item(ssevents.named("a", "data-a")),
+    ssevents.comment("ignore"),
+    ssevents.event_item(ssevents.named("b", "data-b")),
+    ssevents.heartbeat(),
+  ]
+  let events = ssevents.events_of(items)
+  case events {
+    [first, second] -> {
+      ssevents.name_of(first) |> should.equal(Some("a"))
+      ssevents.name_of(second) |> should.equal(Some("b"))
+    }
+    _ -> should.fail()
+  }
+}
+
+pub fn comment_texts_of_filters_to_comment_text_test() {
+  let items = [
+    ssevents.event_item(ssevents.new("payload")),
+    ssevents.comment("hello"),
+    ssevents.comment("world"),
+  ]
+  ssevents.comment_texts_of(items)
+  |> should.equal(["hello", "world"])
+}
+
+// The README example from Issue #77 — pin down that pattern-matching
+// on a decoded item now works through `ssevents.event_of_item` rather
+// than reaching into ssevents/event for the EventItem variant.
+pub fn issue_77_decode_and_inspect_first_event_test() {
+  let wire = "event: job.update\ndata: hello\n\n"
+  let assert Ok(items) = ssevents.decode(wire)
+  case ssevents.events_of(items) {
+    [first, ..] -> ssevents.name_of(first) |> should.equal(Some("job.update"))
+    [] -> should.fail()
+  }
+}


### PR DESCRIPTION
## Summary

Issue #77: `ssevents.Item` is re-exported from the top-level module as a type alias, but Gleam's type aliases do not carry the underlying `EventItem` / `CommentItem` constructors. Every caller that decodes an SSE stream and wants to pattern-match on the result has been forced to add `import ssevents/event.{type Item, EventItem, CommentItem}` purely to access the variants.

This PR adds Item-level accessor helpers on the facade so the `ssevents`-only import suffices for the common cases:

- `is_event/1` / `is_comment/1` — shape predicates
- `event_of_item/1 -> Option(Event)` / `comment_text_of_item/1 -> Option(String)` — single-item extractors
- `events_of/1 -> List(Event)` / `comment_texts_of/1 -> List(String)` — list-level filters for the "I just want the events" pattern

The underlying `Item` type stays a type alias of `event.Item` (no breaking re-shaping) and the `EventItem` / `CommentItem` constructors remain available for code that does want to pattern-match by importing `ssevents/event` explicitly.

## Changes

- `src/ssevents/event.gleam` — five new public helpers near the existing `Item` definition: `is_event`, `is_comment`, `event_of_item`, `comment_text_of_item`. The implementation lives next to the type so the discrimination knowledge stays in one place.
- `src/ssevents.gleam` — corresponding facade re-exports of the four helpers above, plus two list-level convenience functions (`events_of` and `comment_texts_of`) that build on `gleam/list.filter_map`.
- `test/ssevents/event_test.gleam` — seven new tests:
  - `is_event_distinguishes_event_and_comment_test` — predicates over both variants.
  - `event_of_item_returns_event_for_event_item_test` / `event_of_item_returns_none_for_comment_test` — single-item extractor.
  - `comment_text_of_item_returns_text_for_comment_test` / `comment_text_of_item_returns_none_for_event_test` — comment side.
  - `events_of_filters_to_event_payloads_test` / `comment_texts_of_filters_to_comment_text_test` — list-level filters.
  - `issue_77_decode_and_inspect_first_event_test` — pins the issue's own example: decode wire bytes, walk events with `events_of`, read the event name through the facade alone.
- `CHANGELOG.md` — Unreleased entry under `### Added`.

## Design Decisions

- **Accessors over re-exporting variants.** Re-defining the variants on the facade (`pub type Item { EventItem(Event); CommentItem(Comment) }`) would create a *different* type and break the existing `pub type Item = event.Item` alias contract: code that already imports `ssevents.Item` would still expect it to interoperate with `ssevents/event.Item`. Helper functions sidestep that and let the alias keep its no-conversion identity.
- **`Option`, not `Result`, for extractors.** "Not an event" is not an error — it's the other half of the sum type. `Option` matches the existing `name_of/1` / `id_of/1` shape and reads naturally with `case`.
- **List-level helpers built on `gleam/list.filter_map`.** Matches the rest of the standard library's idioms; no hand-rolled `list_filter_map` accumulator on the facade.
- **No README change in this PR.** The README's quick-start does not currently show pattern-matching on a decoded item, so adding the new helpers there would expand scope. The CHANGELOG entry surfaces the new shape; documentation polish is a natural follow-up.

## Limitations

- Does not change the existing `Item` type alias or the underlying constructor names; callers that prefer pattern-matching can still `import ssevents/event` directly. This PR only removes the *requirement* to do so for the common cases.
- The `events_of` / `comment_texts_of` filters allocate a new list. For very large streams, callers should reach for the per-chunk decode path (`stream.decode_stream`) rather than collecting items first.

Closes #77