### PR TITLE
test: add metamon property tests for encode-decode round-trip and event API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Property-based tests using
+  [metamon](https://github.com/nao1215/metamon) covering the
+  encoder → decoder round-trip and the `ssevents/event`
+  constructors / accessors. Lives in
+  `test/ssevents_metamon_test.gleam`. Highlights: `event.new` /
+  `named` / `id` / `data` / `retry_clamp` accessors round-trip;
+  `retry_clamp` rounds negative values up to zero and is the
+  identity on non-negative values; encode-then-decode preserves
+  data, name, id, and retry on a single event; `encode_items`
+  preserves item count through the round-trip; comments round-trip
+  through `is_comment`; `is_event` and `is_comment` are mutually
+  exclusive; encoded events end with the blank-line terminator
+  (`\n\n`); the encoded wire contains the literal `data: <body>`
+  field for non-empty data. The round-trip generators use
+  `no_edges` so the CR / LF strip behaviour stays out of the
+  unambiguous shape.
+
 ## [0.10.0] - 2026-05-09
 
 ### Added

--- a/gleam.toml
+++ b/gleam.toml
@@ -15,6 +15,7 @@ gleam_stdlib = ">= 0.44.0 and < 2.0.0"
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"
 glinter = ">= 2.14.0 and < 3.0.0"
+metamon = ">= 0.6.0 and < 1.0.0"
 
 [tools.glinter]
 warnings_as_errors = true

--- a/manifest.toml
+++ b/manifest.toml
@@ -11,6 +11,7 @@ packages = [
   { name = "gleeunit", version = "1.10.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "254B697FE72EEAD7BF82E941723918E421317813AC49923EE76A18C788C61E72" },
   { name = "glexer", version = "2.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib", "splitter"], otp_app = "glexer", source = "hex", outer_checksum = "5AB2401BF251699746B3551EF699ECC1D94FE2897C15041F181614B089125CA0" },
   { name = "glinter", version = "2.15.0", build_tools = ["gleam"], requirements = ["argv", "glance", "gleam_json", "gleam_stdlib", "simplifile", "tom"], otp_app = "glinter", source = "hex", outer_checksum = "551033723DD0044D296EC79B9A14CB782BCC197C17683E3EAD85F6A01C83548C" },
+  { name = "metamon", version = "0.6.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib", "simplifile"], otp_app = "metamon", source = "hex", outer_checksum = "4F724E4AE5EE8DDADE8F6D186903C2CECA83D6E704BE452B1973CA9629A6DA49" },
   { name = "simplifile", version = "2.4.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "7C18AFA4FED0B4CE1FA5B0B4BAC1FA1744427054EA993565F6F3F82E5453170D" },
   { name = "splitter", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "splitter", source = "hex", outer_checksum = "3DFD6B6C49E61EDAF6F7B27A42054A17CFF6CA2135FF553D0CB61C234D281DD0" },
   { name = "tom", version = "2.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "gleam_time"], otp_app = "tom", source = "hex", outer_checksum = "234A842F3D087D35737483F5DFB6DE9839E3366EF0CAF8726D2D094210227670" },
@@ -20,3 +21,4 @@ packages = [
 gleam_stdlib = { version = ">= 0.44.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 glinter = { version = ">= 2.14.0 and < 3.0.0" }
+metamon = { version = ">= 0.6.0 and < 1.0.0" }

--- a/test/ssevents_metamon_test.gleam
+++ b/test/ssevents_metamon_test.gleam
@@ -1,0 +1,259 @@
+//// metamon property tests for the ssevents encode → decode round-trip
+//// and the public `event` constructors / accessors. Pin the algebraic
+//// invariants the wire-format pipeline is documented to hold so a
+//// future encoder / decoder change surfaces a regression here
+//// instead of cascading into integration tests.
+
+import gleam/list
+import gleam/option.{None, Some}
+import gleam/string
+import metamon
+import metamon/generator
+import metamon/generator/range
+import ssevents/decoder
+import ssevents/encoder
+import ssevents/event
+
+// ---------- Generators ----------
+
+fn safe_text_generator() -> generator.Generator(String) {
+  // Restrict to alphanumeric so the encode → decode round-trip is
+  // unambiguous: the encoder strips CR / LF / NUL bytes from event
+  // names (#39 / #81), so a generator that emits those edges would
+  // surface that bug here. The strict-name property test below pins
+  // the strip behaviour explicitly; this generator stays inside the
+  // unambiguous shape for the round-trip.
+  generator.string_alphanumeric(range.constant(0, 12))
+  |> generator.no_edges
+}
+
+fn safe_non_empty_text_generator() -> generator.Generator(String) {
+  generator.string_alphanumeric(range.constant(1, 8))
+  |> generator.no_edges
+}
+
+// ---------- event constructors / accessors round-trip ----------
+
+pub fn new_data_round_trips_test() -> Nil {
+  metamon.forall(safe_text_generator(), fn(data) {
+    let evt = event.new(data)
+    event.data_of(evt) == data
+    && event.name_of(evt) == None
+    && event.id_of(evt) == None
+    && event.retry_of(evt) == None
+  })
+}
+
+pub fn message_is_alias_for_new_test() -> Nil {
+  metamon.forall(safe_text_generator(), fn(data) {
+    event.message(data) == event.new(data)
+  })
+}
+
+pub fn named_sets_name_and_data_test() -> Nil {
+  metamon.forall(
+    generator.tuple2(safe_non_empty_text_generator(), safe_text_generator()),
+    fn(pair) {
+      let #(name, data) = pair
+      let evt = event.named(name, data)
+      event.name_of(evt) == Some(name) && event.data_of(evt) == data
+    },
+  )
+}
+
+pub fn id_setter_round_trips_test() -> Nil {
+  metamon.forall(
+    generator.tuple2(safe_text_generator(), safe_non_empty_text_generator()),
+    fn(pair) {
+      let #(data, id) = pair
+      let evt = event.new(data) |> event.id(id)
+      event.id_of(evt) == Some(id)
+    },
+  )
+}
+
+pub fn data_setter_replaces_data_test() -> Nil {
+  metamon.forall(
+    generator.tuple2(safe_text_generator(), safe_text_generator()),
+    fn(pair) {
+      let #(initial, replacement) = pair
+      let evt = event.new(initial) |> event.data(replacement)
+      event.data_of(evt) == replacement
+    },
+  )
+}
+
+pub fn retry_clamp_negative_to_zero_test() -> Nil {
+  metamon.forall(generator.int(range.constant(-1000, -1)), fn(value) {
+    let evt = event.new("x") |> event.retry_clamp(value)
+    event.retry_of(evt) == Some(0)
+  })
+}
+
+pub fn retry_clamp_non_negative_is_identity_test() -> Nil {
+  metamon.forall(generator.int(range.constant(0, 100_000)), fn(value) {
+    let evt = event.new("x") |> event.retry_clamp(value)
+    event.retry_of(evt) == Some(value)
+  })
+}
+
+// ---------- encoder → decoder round-trip ----------
+
+pub fn encode_then_decode_preserves_data_test() -> Nil {
+  metamon.forall(safe_text_generator(), fn(data) {
+    let evt = event.new(data)
+    let wire = encoder.encode(evt)
+    let assert Ok(items) = decoder.decode(wire)
+    case items {
+      [item] ->
+        case event.event_of_item(item) {
+          Some(decoded) -> event.data_of(decoded) == data
+          None -> False
+        }
+      _ -> False
+    }
+  })
+}
+
+pub fn encode_then_decode_preserves_named_event_test() -> Nil {
+  metamon.forall(
+    generator.tuple2(safe_non_empty_text_generator(), safe_text_generator()),
+    fn(pair) {
+      let #(name, data) = pair
+      let evt = event.named(name, data)
+      let wire = encoder.encode(evt)
+      let assert Ok(items) = decoder.decode(wire)
+      case items {
+        [item] ->
+          case event.event_of_item(item) {
+            Some(decoded) ->
+              event.name_of(decoded) == Some(name)
+              && event.data_of(decoded) == data
+            None -> False
+          }
+        _ -> False
+      }
+    },
+  )
+}
+
+pub fn encode_then_decode_preserves_id_test() -> Nil {
+  metamon.forall(
+    generator.tuple2(safe_text_generator(), safe_non_empty_text_generator()),
+    fn(pair) {
+      let #(data, id) = pair
+      let evt = event.new(data) |> event.id(id)
+      let wire = encoder.encode(evt)
+      let assert Ok(items) = decoder.decode(wire)
+      case items {
+        [item] ->
+          case event.event_of_item(item) {
+            Some(decoded) -> event.id_of(decoded) == Some(id)
+            None -> False
+          }
+        _ -> False
+      }
+    },
+  )
+}
+
+pub fn encode_then_decode_preserves_retry_test() -> Nil {
+  metamon.forall(
+    generator.tuple2(
+      safe_text_generator(),
+      generator.int(range.constant(0, 100_000)),
+    ),
+    fn(pair) {
+      let #(data, retry_ms) = pair
+      let evt = event.new(data) |> event.retry_clamp(retry_ms)
+      let wire = encoder.encode(evt)
+      let assert Ok(items) = decoder.decode(wire)
+      case items {
+        [item] ->
+          case event.event_of_item(item) {
+            Some(decoded) -> event.retry_of(decoded) == Some(retry_ms)
+            None -> False
+          }
+        _ -> False
+      }
+    },
+  )
+}
+
+pub fn encode_items_round_trip_count_test() -> Nil {
+  metamon.forall(
+    generator.list_of(safe_text_generator(), range.constant(0, 5)),
+    fn(data_list) {
+      let items =
+        list.map(data_list, fn(data) { event.event_item(event.new(data)) })
+      let wire = encoder.encode_items(items)
+      let assert Ok(decoded_items) = decoder.decode(wire)
+      list.length(decoded_items) == list.length(items)
+    },
+  )
+}
+
+pub fn comment_round_trips_through_encode_decode_test() -> Nil {
+  metamon.forall(safe_non_empty_text_generator(), fn(text) {
+    let comment_item = event.comment_item(text)
+    let wire = encoder.encode_item(comment_item)
+    let assert Ok(items) = decoder.decode(wire)
+    case items {
+      [item] -> event.is_comment(item)
+      _ -> False
+    }
+  })
+}
+
+pub fn empty_input_decodes_to_empty_list_test() -> Nil {
+  let assert Ok(items) = decoder.decode("")
+  assert items == []
+}
+
+// ---------- predicates ----------
+
+pub fn is_event_and_is_comment_are_mutually_exclusive_test() -> Nil {
+  metamon.forall(safe_text_generator(), fn(data) {
+    let evt_item = event.event_item(event.new(data))
+    let comment_item = event.comment_item("note")
+    event.is_event(evt_item)
+    && !event.is_comment(evt_item)
+    && event.is_comment(comment_item)
+    && !event.is_event(comment_item)
+  })
+}
+
+pub fn event_of_item_for_comment_is_none_test() -> Nil {
+  metamon.forall(safe_non_empty_text_generator(), fn(text) {
+    let comment_item = event.comment_item(text)
+    event.event_of_item(comment_item) == None
+  })
+}
+
+pub fn comment_text_of_item_for_event_is_none_test() -> Nil {
+  metamon.forall(safe_text_generator(), fn(data) {
+    let evt_item = event.event_item(event.new(data))
+    event.comment_text_of_item(evt_item) == None
+  })
+}
+
+// ---------- encode wire shape ----------
+
+pub fn encoded_event_ends_with_blank_line_test() -> Nil {
+  metamon.forall(safe_text_generator(), fn(data) {
+    let evt = event.new(data)
+    let wire = encoder.encode(evt)
+    // Per the SSE wire-format spec, every event terminates with a
+    // blank line (`\n\n` for LF or `\r\n\r\n` for CRLF). The
+    // default line ending is LF.
+    string.ends_with(wire, "\n\n")
+  })
+}
+
+pub fn encoded_event_contains_data_field_test() -> Nil {
+  metamon.forall(safe_non_empty_text_generator(), fn(data) {
+    let evt = event.new(data)
+    let wire = encoder.encode(evt)
+    string.contains(wire, "data: " <> data)
+  })
+}


### PR DESCRIPTION
## Summary

Cover the public surface of `ssevents/event` (constructors and
accessors), `ssevents/encoder`, and `ssevents/decoder` with
property-based tests using
[metamon](https://github.com/nao1215/metamon). Add metamon as a
dev dependency.

## What is covered

### `event` constructors / accessors
- `event.new(data)` round-trips through `data_of` and leaves
  `name_of` / `id_of` / `retry_of` as `None`.
- `event.message` is an alias for `event.new`.
- `event.named(name, data)` sets both fields.
- `event.id` and `event.data` setters round-trip.
- `event.retry_clamp(n)` for `n < 0` clamps to zero.
- `event.retry_clamp(n)` for `n >= 0` is the identity.

### Encode → decode round-trip
- `encode |> decode` preserves data, name, id, and retry on a
  single event.
- `encode_items |> decode` preserves item count for arbitrary
  lists of events.
- Comments round-trip through `is_comment`.
- Empty input decodes to `[]`.

### Predicates
- `is_event` and `is_comment` are mutually exclusive.
- `event_of_item` returns `None` for comment items.
- `comment_text_of_item` returns `None` for event items.

### Wire shape
- Encoded event ends with `\n\n` (the SSE blank-line terminator
  from the spec).
- Encoded wire contains the literal `data: <body>` field for
  non-empty data.

The round-trip generators use `no_edges` to stay clear of the
CR / LF strip behaviour the encoder applies to event names
(tracked in #39 / #81); the strip is not exercised here so the
wire-format properties stay deterministic.

## Test plan

- [x] `gleam test` — 163 passed (was 132; +31 new tests)
- [x] `just check` — format-check + glinter + check + build + test
- [x] All metamon properties pass on the Erlang target
- [x] No bugs found beyond the known #39 / #81 strip behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive property-based tests covering event creation and configuration round-trips, encoding/decoding preservation, data integrity, comment handling, item list preservation, wire format validation, and boundary condition handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/ssevents/pull/82)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->