### PR TITLE
feat(event): add event_checked / id_checked / named_checked / comment_checked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **`ssevents/event`**: `event_checked` / `id_checked` /
+  `named_checked` / `comment_checked` are the typed-error
+  counterparts of the existing `event` / `id` / `named` /
+  `comment` constructors. The non-strict variants silently strip
+  CR / LF / NUL bytes from the values that flow into SSE field
+  lines (so `named("\n", _)` produces `name = ""`, and
+  `id(_, "ab\u{0000}cd")` produces `id = "abcd"` — a *different
+  valid id* that can silently match the wrong subscription
+  channel on Last-Event-ID resume). The strict variants surface
+  bad input as
+  `Error(NameContainsControlBytes(value:))` /
+  `Error(IdContainsControlBytes(value:))` /
+  `Error(CommentContainsControlBytes(value:))` so callers
+  passing user-typed or upstream data can render an actionable
+  error rather than producing the wrong wire silently. Add the
+  matching `EventError` type (re-exported from the top-level
+  `ssevents` module) and a `comment_item_of/1` helper that wraps
+  an already-validated `Comment` into an `Item`. The existing
+  non-strict variants keep their void return for backward
+  compatibility, with doc-comments updated to point at the strict
+  counterparts. (#81)
 - Property-based tests using
   [metamon](https://github.com/nao1215/metamon) covering the
   encoder → decoder round-trip and the `ssevents/event`

--- a/src/ssevents.gleam
+++ b/src/ssevents.gleam
@@ -52,6 +52,10 @@ pub type ReconnectState =
 pub type SseError =
   error.SseError
 
+/// Re-export of `ssevents/event.EventError`.
+pub type EventError =
+  event.EventError
+
 pub type Iterator(a) =
   stream.Iterator(a)
 
@@ -109,6 +113,48 @@ pub fn event(event: Event, name: String) -> Event {
 
 pub fn id(event: Event, id: String) -> Event {
   event.id(event, id)
+}
+
+/// Strict counterpart of `event/2`: returns
+/// `Error(NameContainsControlBytes(value:))` when the name
+/// contains CR / LF / NUL bytes, otherwise sets the SSE
+/// `event:` field name. Use when the name comes from user-typed
+/// or upstream input and silent stripping would lose data the
+/// caller cares about. (#81)
+pub fn event_checked(event: Event, name: String) -> Result(Event, EventError) {
+  event.event_checked(event, name)
+}
+
+/// Strict counterpart of `id/2`: returns
+/// `Error(IdContainsControlBytes(value:))` when the id contains
+/// CR / LF / NUL bytes. The strip on id is especially dangerous —
+/// `id(_, "ab\u{0000}cd")` produces an event with `id = "abcd"`,
+/// silently mutating an authorisation-relevant identifier on
+/// reconnect (Last-Event-ID resume). The strict variant catches
+/// this at the builder boundary. (#81)
+pub fn id_checked(event: Event, id: String) -> Result(Event, EventError) {
+  event.id_checked(event, id)
+}
+
+/// Strict counterpart of `named/2`: returns
+/// `Error(NameContainsControlBytes(value:))` when the name
+/// contains CR / LF / NUL bytes. Convenience for the common
+/// `new |> event_checked` pipeline. (#81)
+pub fn named_checked(name: String, data: String) -> Result(Event, EventError) {
+  event.named_checked(name, data)
+}
+
+/// Strict counterpart of `comment/1`: returns
+/// `Error(CommentContainsControlBytes(value:))` when the comment
+/// text contains CR / LF / NUL bytes. The non-strict `comment/1`
+/// silently strips these bytes; WHATWG SSE §9.2.6 has no notion
+/// of a multi-line comment, so embedded line breaks would fan out
+/// into multiple comments on the wire. (#81)
+pub fn comment_checked(text: String) -> Result(Item, EventError) {
+  case event.comment_checked(text) {
+    Ok(comment) -> Ok(event.comment_item_of(comment))
+    Error(error_value) -> Error(error_value)
+  }
 }
 
 /// Set the SSE `retry:` reconnection time on an event.

--- a/src/ssevents/event.gleam
+++ b/src/ssevents/event.gleam
@@ -40,11 +40,41 @@ pub type Item {
   CommentItem(Comment)
 }
 
+/// Reasons the strict event-builder variants reject input.
+///
+/// The non-strict `event` / `id` / `named` / `comment` constructors
+/// silently strip CR / LF / NUL bytes from the values that flow into
+/// SSE field lines (so `named("\n", _)` produces an event with
+/// `name = ""`, and `id(_, "ab\u{0000}cd")` produces an event with
+/// `id = "abcd"` — a *different valid id*). The silent strip is
+/// data loss the caller cannot observe — a naive equality check on
+/// the recovered name silently matches the wrong subscription
+/// channel. The `*_checked` variants surface this as a typed error
+/// so callers can render "name `foo\\nbar` contains forbidden
+/// control bytes" rather than producing the wrong wire silently.
+/// (#81)
+pub type EventError {
+  /// `event_checked` saw CR / LF / NUL bytes in the event name.
+  /// Carries the original (un-sanitized) value.
+  NameContainsControlBytes(value: String)
+  /// `id_checked` saw CR / LF / NUL bytes in the event id.
+  /// Carries the original (un-sanitized) value.
+  IdContainsControlBytes(value: String)
+  /// `comment_checked` saw CR / LF / NUL bytes in the comment text.
+  /// Carries the original (un-sanitized) value.
+  CommentContainsControlBytes(value: String)
+}
+
 /// Build a `Comment` from a text payload. CR (U+000D), LF (U+000A),
 /// and NUL (U+0000) are stripped at construction so the result
 /// round-trips through `encode → decode` without fanning out into
 /// multiple comments. Matches the `sanitize_field_value` posture
 /// already used for `event_name` and `id`.
+///
+/// The silent strip is data loss the caller cannot observe. Reach
+/// for `comment_checked/1` instead when comment text comes from
+/// user-typed or upstream input and a typed error is preferable to
+/// a silently-truncated comment. (#81)
 pub fn comment(text: String) -> Comment {
   Comment(text: sanitize_field_value(text))
 }
@@ -58,6 +88,14 @@ pub fn comment_text_of(c: Comment) -> String {
 /// `CommentItem(comment(text))` two-step.
 pub fn comment_item(text: String) -> Item {
   CommentItem(comment(text))
+}
+
+/// Wrap an already-validated `Comment` as a stream item. Companion
+/// to `comment_checked/1` so callers can keep the typed-error
+/// pipeline `text -> Result(Comment, EventError) -> Result(Item, _)`
+/// without reaching into `Item`'s constructors. (#81)
+pub fn comment_item_of(c: Comment) -> Item {
+  CommentItem(c)
 }
 
 /// Issue #77: Item-level accessors. The `Item` variants `EventItem` /
@@ -124,10 +162,21 @@ pub fn message(data: String) -> Event {
   new(data)
 }
 
+/// Build an event with both `name` and `data`. CR / LF / NUL bytes
+/// in `name` are silently stripped — see the warning on `event/2`.
+/// Reach for `named_checked/2` when the bad-input case must be
+/// surfaced as a typed error. (#81)
 pub fn named(name: String, data: String) -> Event {
   new(data) |> event(name)
 }
 
+/// Set the SSE `event:` field name on an event. CR / LF / NUL bytes
+/// are silently stripped to keep the wire spec-compliant — so
+/// `named("\n", _)` produces an event with `name = ""`. The strip
+/// is data loss the caller cannot observe; reach for
+/// `event_checked/2` when the name comes from user-typed or
+/// upstream input and a typed error is preferable to silent data
+/// loss. (#81)
 pub fn event(event: Event, name: String) -> Event {
   Event(
     event: Some(sanitize_field_value(name)),
@@ -137,6 +186,13 @@ pub fn event(event: Event, name: String) -> Event {
   )
 }
 
+/// Set the SSE `id:` Last-Event-ID on an event. CR / LF / NUL bytes
+/// are silently stripped — so `id(_, "ab\u{0000}cd")` produces an
+/// event with `id = "abcd"`, a *different valid id*, which can
+/// silently match the wrong subscription channel on reconnect.
+/// Reach for `id_checked/2` when the id comes from user-typed or
+/// upstream input and a typed error is preferable to silent
+/// authorization-relevant identifier mutation. (#81)
 pub fn id(event: Event, id: String) -> Event {
   Event(
     event: event.event,
@@ -144,6 +200,83 @@ pub fn id(event: Event, id: String) -> Event {
     id: Some(sanitize_field_value(id)),
     retry: event.retry,
   )
+}
+
+/// Strict counterpart of `event/2`: rejects names containing CR /
+/// LF / NUL bytes with `Error(NameContainsControlBytes(value:))`.
+///
+/// The non-strict `event/2` silently strips these bytes (so
+/// `named("\n", _)` produces a part with `name = ""`). For callers
+/// passing user-typed or upstream data into the event name and want
+/// to surface bad inputs as a typed error rather than silent data
+/// loss, use this variant. The `value` payload carries the
+/// caller's original input so the error renders as
+/// "event name `foo\\nbar` contains forbidden control bytes". (#81)
+pub fn event_checked(
+  source_event: Event,
+  name: String,
+) -> Result(Event, EventError) {
+  case has_forbidden_byte(name) {
+    True -> Error(NameContainsControlBytes(value: name))
+    False -> Ok(event(source_event, name))
+  }
+}
+
+/// Strict counterpart of `id/2`: rejects ids containing CR / LF /
+/// NUL bytes with `Error(IdContainsControlBytes(value:))`.
+///
+/// The non-strict `id/2` silently strips these bytes. The strip on
+/// the id is especially dangerous — `id(_, "ab\u{0000}cd")`
+/// produces an event with `id = "abcd"`, a *different valid id*,
+/// which can silently match the wrong subscription channel on
+/// reconnect (Last-Event-ID resume). The strict variant catches
+/// this at the builder boundary so the wrong wire never gets
+/// produced. (#81)
+pub fn id_checked(event: Event, id: String) -> Result(Event, EventError) {
+  case has_forbidden_byte(id) {
+    True -> Error(IdContainsControlBytes(value: id))
+    False -> Ok(id_internal(event, id))
+  }
+}
+
+fn id_internal(event: Event, id_value: String) -> Event {
+  Event(
+    event: event.event,
+    data: event.data,
+    id: Some(sanitize_field_value(id_value)),
+    retry: event.retry,
+  )
+}
+
+/// Strict counterpart of `named/2`: rejects names containing CR /
+/// LF / NUL bytes with `Error(NameContainsControlBytes(value:))`.
+///
+/// Convenience for the common `new |> event_checked` pipeline that
+/// also constructs a fresh `Event`. (#81)
+pub fn named_checked(name: String, data: String) -> Result(Event, EventError) {
+  event_checked(new(data), name)
+}
+
+/// Strict counterpart of `comment/1`: rejects comment text
+/// containing CR / LF / NUL bytes with
+/// `Error(CommentContainsControlBytes(value:))`.
+///
+/// The non-strict `comment/1` silently strips these bytes.
+/// WHATWG SSE §9.2.6 has no notion of a multi-line comment, so
+/// embedded line breaks would fan out into multiple comments on
+/// the wire; the strict variant surfaces this as an explicit
+/// error rather than silently splitting the caller's intent. (#81)
+pub fn comment_checked(text: String) -> Result(Comment, EventError) {
+  case has_forbidden_byte(text) {
+    True -> Error(CommentContainsControlBytes(value: text))
+    False -> Ok(comment(text))
+  }
+}
+
+fn has_forbidden_byte(value: String) -> Bool {
+  string.contains(value, "\r")
+  || string.contains(value, "\n")
+  || string.contains(value, "\u{0000}")
 }
 
 /// Strip CR (U+000D), LF (U+000A), and NUL (U+0000) from `value`.

--- a/test/ssevents/event_test.gleam
+++ b/test/ssevents/event_test.gleam
@@ -1,6 +1,7 @@
 import gleam/option.{None, Some}
 import gleeunit/should
 import ssevents
+import ssevents/event
 
 pub fn event_builder_accessors_test() {
   let event =
@@ -337,4 +338,70 @@ pub fn issue_77_decode_and_inspect_first_event_test() {
     [first, ..] -> ssevents.name_of(first) |> should.equal(Some("job.update"))
     [] -> should.fail()
   }
+}
+
+// ---------- _checked variants (#81) ----------
+
+pub fn event_checked_accepts_safe_name_test() {
+  let assert Ok(evt) =
+    ssevents.new("data") |> ssevents.event_checked("job.update")
+  ssevents.name_of(evt) |> should.equal(Some("job.update"))
+}
+
+pub fn event_checked_rejects_lf_in_name_test() {
+  ssevents.new("data")
+  |> ssevents.event_checked("bad\nname")
+  |> should.equal(Error(event.NameContainsControlBytes(value: "bad\nname")))
+}
+
+pub fn event_checked_rejects_cr_in_name_test() {
+  ssevents.new("data")
+  |> ssevents.event_checked("bad\rname")
+  |> should.equal(Error(event.NameContainsControlBytes(value: "bad\rname")))
+}
+
+pub fn event_checked_rejects_nul_in_name_test() {
+  ssevents.new("data")
+  |> ssevents.event_checked("bad\u{0000}name")
+  |> should.equal(
+    Error(event.NameContainsControlBytes(value: "bad\u{0000}name")),
+  )
+}
+
+pub fn id_checked_accepts_safe_id_test() {
+  let assert Ok(evt) = ssevents.new("data") |> ssevents.id_checked("job-1")
+  ssevents.id_of(evt) |> should.equal(Some("job-1"))
+}
+
+pub fn id_checked_rejects_nul_in_id_test() {
+  // The repro from #81 — `id(_, "ab\u{0000}cd")` would silently
+  // produce an event with `id = "abcd"`, mutating the
+  // authorization-relevant identifier. The strict variant must
+  // refuse the input outright.
+  ssevents.new("data")
+  |> ssevents.id_checked("ab\u{0000}cd")
+  |> should.equal(Error(event.IdContainsControlBytes(value: "ab\u{0000}cd")))
+}
+
+pub fn named_checked_accepts_safe_inputs_test() {
+  let assert Ok(evt) = ssevents.named_checked("topic", "payload")
+  ssevents.name_of(evt) |> should.equal(Some("topic"))
+  ssevents.data_of(evt) |> should.equal("payload")
+}
+
+pub fn named_checked_rejects_lf_in_name_test() {
+  ssevents.named_checked("\n", "x")
+  |> should.equal(Error(event.NameContainsControlBytes(value: "\n")))
+}
+
+pub fn comment_checked_accepts_safe_text_test() {
+  let assert Ok(item) = ssevents.comment_checked("ping")
+  ssevents.is_comment(item) |> should.equal(True)
+}
+
+pub fn comment_checked_rejects_lf_in_text_test() {
+  ssevents.comment_checked("multi\nline")
+  |> should.equal(
+    Error(event.CommentContainsControlBytes(value: "multi\nline")),
+  )
 }


### PR DESCRIPTION
## Summary

The existing `event` / `id` / `named` / `comment` constructors
silently strip CR / LF / NUL bytes from the values that flow into
SSE field lines. The strip closes the wire-corruption mode from
#39 but introduces silent data loss the caller cannot observe.

- `named(\"\\n\", _)` produces `name = \"\"`. A naive equality check
  on the recovered name silently matches the wrong subscription
  channel.
- `id(_, \"ab\\u{0000}cd\")` produces `id = \"abcd\"`, a *different
  valid id* that can silently match the wrong Last-Event-ID on
  reconnect. The attacker can craft `\\u{0000}`-laced ids that
  target a privileged identifier after stripping.

Add typed-error counterparts.

## Changes

### `src/ssevents/event.gleam`

- New `EventError` type with three variants:
  `NameContainsControlBytes(value:)`,
  `IdContainsControlBytes(value:)`,
  `CommentContainsControlBytes(value:)`. Each carries the
  original (un-sanitized) input so the error renders as
  \"name `foo\\\\nbar` contains forbidden control bytes\".
- `event_checked(source_event, name)`,
  `id_checked(event, id)`,
  `named_checked(name, data)`,
  `comment_checked(text)` — all return `Result(_, EventError)`.
- `comment_item_of(comment) -> Item` wraps an already-validated
  `Comment` into an `Item` so callers can keep the typed-error
  pipeline through the facade.
- Update the existing `event` / `id` / `named` / `comment`
  doc-comments to warn about the silent strip and point at the
  strict counterparts.
- Reuse the existing `sanitize_field_value` predicate via a new
  internal `has_forbidden_byte/1` helper.

### `src/ssevents.gleam`

- Re-export `EventError` as a type alias.
- Re-export `event_checked` / `id_checked` / `named_checked` /
  `comment_checked` as facade-level functions. The facade
  `comment_checked` returns `Result(Item, EventError)` (wraps
  the validated `Comment` with `comment_item_of`) so callers
  staying inside `ssevents` get the same `Item`-yielding shape
  as the non-strict `comment/1`.

### `test/ssevents/event_test.gleam`

- Ten new `*_checked` tests covering: safe inputs return
  `Ok(_)`, LF / CR / NUL in the event name, the NUL-in-id repro
  from the issue body (`\"ab\\u{0000}cd\"` is rejected outright
  rather than silently producing `\"abcd\"`), LF in comment
  text.

### `CHANGELOG.md`

- Added entry under `[Unreleased]`.

## Design Decisions

**Why match the multipartkit / dataprep pattern.** The whole
suite is converging on the `*_checked` shape for adversarial
input. Every previous PR in this batch (multipartkit
`add_field_strict` / `add_file_strict`, dataprep
`parse.float_strict`, oaspec yaml-safe-ffi) follows the same
shape: keep the existing infallible constructor for backward
compatibility, add a typed-error sibling for callers who need
the rejection path. Doing this for ssevents keeps the API
surface predictable across packages.

**Why three variants and not one
`HeaderInjectionAttempt(field:, value:)`.** Pattern-matching on
specific variants reads better at the call site than threading
a field name through. Rendering also stays cleaner — each
variant maps to one user-facing message without a runtime
field-name lookup.

**Why `comment_checked` returns `Result(Item, _)` at the
facade.** The non-strict `comment/1` at the facade returns
`Item` (it bundles the `comment_item` wrap). Following the
same shape keeps the strict pipeline drop-in compatible:
existing code that does `let item = ssevents.comment(text)` can
become `let assert Ok(item) = ssevents.comment_checked(text)`.

## Test plan

- [x] `gleam test` — 173 passed (was 163; +10 new tests including
      the NUL-in-id repro from the issue body)
- [x] `just check` — format-check + glinter + check + build + test
- [x] No metamon properties had to change
- [x] Existing `event` / `id` / `named` / `comment` callers see
      no breaking change

Closes #81.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Strict validation constructors for Server-Sent Events (names, IDs, and comments) now return specific errors when invalid control bytes are detected, instead of silently removing them
  * New error type with variants for different validation failures
  * Helper function to safely convert validated comments to items

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/ssevents/pull/83)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->