### PR TITLE
docs(readme): flag retry/2 panic and point at strict alternatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- README's `### Encode one event` quick-start now flags
+  `ssevents.retry/2`'s panic-on-negative behaviour and points at
+  `retry_clamp/2` for callers piping untrusted input. The same
+  callout cross-references `event_checked` / `id_checked` /
+  `named_checked` / `comment_checked` (added below) so consumers
+  know about the strict variants for the CR / LF / NUL strip
+  case as well. Closes the discoverability gap from #80 — the
+  panic was already documented in the function's docstring, but
+  a user dropping in `retry(req.body.user_provided_ms)` had to
+  go to source to find it. (#80)
+
 ### Added
 
 - **`ssevents/event`**: `event_checked` / `id_checked` /

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ pub fn encode_example() -> BitArray {
 }
 ```
 
+> **`retry/2` panics on negative input.** WHATWG SSE §9.2.6 only
+> recognises a non-negative reconnection time, so `ssevents.retry(_,
+> ms)` for `ms < 0` raises a structured panic rather than emit a
+> contract-violating wire. If the value comes from untrusted input
+> (a request field, a deserialised config, a CLI flag), reach for
+> `ssevents.retry_clamp/2` — it silently rounds negative values up
+> to `0` and is otherwise identical. Same posture applies if the
+> name / id / comment text comes from untrusted input: prefer the
+> `*_checked` variants (`event_checked`, `id_checked`,
+> `named_checked`, `comment_checked`) so CR / LF / NUL bytes
+> surface as `EventError` instead of being silently stripped.
+
 ### Encode a whole SSE response body
 
 ```gleam


### PR DESCRIPTION
## Summary

The README's \"Encode one event\" quick-start uses the literal
`ssevents.retry(5000)` line without flagging that `retry/2` panics
on `ms < 0`. The function's docstring states this clearly, but a
user dropping in `retry(req.body.user_provided_ms)` would have to
go to source to find the warning, and would crash on adversarial
input in the meantime. Add a short callout under the encode
example.

## Changes

### `README.md`

- New blockquote callout under `### Encode one event` covering:
  1. `retry/2` panics on `ms < 0` (deliberate posture from #73 —
     the SSE spec mandates a non-negative reconnection time).
  2. Reach for `retry_clamp/2` if the value comes from
     untrusted input.
  3. Cross-reference the new `*_checked` variants
     (`event_checked` / `id_checked` / `named_checked` /
     `comment_checked` from the previous PR for #81) so consumers
     also see the typed-error path for the CR / LF / NUL strip
     case.

### `CHANGELOG.md`

- Documentation entry under `[Unreleased]`.

## Design Decisions

**Why a single callout covering both `retry` and `*_checked`.**
Both are \"adversarial input on the encode side\" patterns and
share the same audience (readers of the quick-start who pipe
request fields into the builder). Splitting them across two
sections risks one of the two being missed; a combined callout
puts the whole \"untrusted input → strict variant\" map in one
place.

**Why no code change.** `retry/2`'s behaviour stays as it is —
panicking on a contract violation is the deliberate posture from
#73. The discoverability gap is purely a README issue.

## Test plan

- [x] `just check` (format-check + glinter + check + build + test)
- [x] No code change; README only

Closes #80.