### PR TITLE
chore(release): prepare v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-10
+
 ### Documentation
 
 - README's `### Encode one event` quick-start now flags

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "ssevents"
-version = "0.10.0"
+version = "0.11.0"
 description = "Server-Sent Events primitives for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "ssevents" }


### PR DESCRIPTION
### Documentation

- README's `### Encode one event` quick-start now flags
  `ssevents.retry/2`'s panic-on-negative behaviour and points at
  `retry_clamp/2` for callers piping untrusted input. The same
  callout cross-references `event_checked` / `id_checked` /
  `named_checked` / `comment_checked` so consumers know about the
  strict variants for the CR / LF / NUL strip case as well.
  Closes the discoverability gap from #80 — the panic was
  already documented in the function's docstring, but a user
  dropping in `retry(req.body.user_provided_ms)` had to go to
  source to find it. (#80)

### Added

- **`ssevents/event`**: `event_checked` / `id_checked` /
  `named_checked` / `comment_checked` are the typed-error
  counterparts of the existing `event` / `id` / `named` /
  `comment` constructors. The non-strict variants silently strip
  CR / LF / NUL bytes from the values that flow into SSE field
  lines (so `named("\n", _)` produces `name = ""`, and
  `id(_, "ab\u{0000}cd")` produces `id = "abcd"` — a *different
  valid id* that can silently match the wrong subscription
  channel on Last-Event-ID resume). The strict variants surface
  bad input as
  `Error(NameContainsControlBytes(value:))` /
  `Error(IdContainsControlBytes(value:))` /
  `Error(CommentContainsControlBytes(value:))` so callers
  passing user-typed or upstream data can render an actionable
  error rather than producing the wrong wire silently. Add the
  matching `EventError` type (re-exported from the top-level
  `ssevents` module) and a `comment_item_of/1` helper that wraps
  an already-validated `Comment` into an `Item`. The existing
  non-strict variants keep their void return for backward
  compatibility, with doc-comments updated to point at the strict
  counterparts. (#81)
- Property-based tests using
  [metamon](https://github.com/nao1215/metamon) covering the
  encoder → decoder round-trip and the `ssevents/event`
  constructors / accessors. Lives in
  `test/ssevents_metamon_test.gleam`. Highlights: `event.new` /
  `named` / `id` / `data` / `retry_clamp` accessors round-trip;
  `retry_clamp` rounds negative values up to zero and is the
  identity on non-negative values; encode-then-decode preserves
  data, name, id, and retry on a single event; `encode_items`
  preserves item count through the round-trip; comments round-trip
  through `is_comment`; `is_event` and `is_comment` are mutually
  exclusive; encoded events end with the blank-line terminator
  (`\n\n`); the encoded wire contains the literal `data: <body>`
  field for non-empty data. The round-trip generators use
  `no_edges` so the CR / LF strip behaviour stays out of the
  unambiguous shape.
