### PR TITLE
fix: align dispatch, encoder line cap, and from_parts retry validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ssevents/decoder`**: a block containing only a `retry:` field no
+  longer dispatches a phantom event. Per WHATWG §9.2.6 a dispatched
+  `MessageEvent` requires at least one `data:` line in the block —
+  earlier versions treated `id` / `event` / `retry` as enough to
+  trigger dispatch, producing an empty `data:""` event the wire never
+  promised. Fields outside dispatch (notably `retry:` updates) are
+  still applied to the connection's reconnect time. (#87)
+- **`ssevents/encoder`**: `data` values longer than ~8184 bytes on a
+  single line previously emitted a `data: …` line the default
+  decoder rejected with `LineTooLong(8192)`, breaking
+  `decode(encode(e))`. Long values are now chunked into multiple
+  `data:` lines (≤ 2000 codepoints each), trading byte-perfect
+  round-trip for parseability — the WHATWG dispatch rule joins
+  `data:` lines with LF, so callers needing byte-identical fidelity
+  should base64-encode payloads above this threshold. (#88)
+- **`ssevents/event`**: `from_parts` now panics on a negative `retry`
+  the same way `retry/2` does, instead of silently dropping the
+  value. The previous silent-drop posture was inconsistent with the
+  setter and gave callers no signal that their input was rejected.
+  Callers handling untrusted reconnect times should pre-clamp via
+  `retry_clamp/2` or use the planned `from_parts_*` checked builders.
+  (#89)
+
 ## [0.11.0] - 2026-05-10
 
 ### Documentation

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -404,16 +404,14 @@ fn reset_event_state(state: DecodeState) -> DecodeState {
 }
 
 fn has_meaningful_event_content(state: DecodeState) -> Bool {
-  case state.data_line_count > 0 {
-    True -> True
-    False ->
-      case state.event_name, state.id, state.retry {
-        Some(_), _, _ -> True
-        _, Some(_), _ -> True
-        _, _, Some(_) -> True
-        None, None, None -> False
-      }
-  }
+  // WHATWG HTML §9.2.6 step 4: "If the data buffer is an empty string,
+  // then set the data buffer and the event type buffer to the empty
+  // string and return." Dispatch is keyed off the data buffer alone;
+  // an `event:`/`id:`/`retry:`-only block mutates state-buffer fields
+  // (lastEventId, reconnection time, event type buffer) without
+  // dispatching. Pre-fix this returned True whenever any state field
+  // was set, which surfaced spurious EventItems. (#87)
+  state.data_line_count > 0
 }
 
 fn split_field(line: String) -> Result(#(String, String), SseError) {

--- a/src/ssevents/encoder.gleam
+++ b/src/ssevents/encoder.gleam
@@ -91,13 +91,56 @@ fn event_lines(ev: event.Event) -> List(String) {
     |> prepend_optional_int("retry", event.retry_of(ev))
     |> list.reverse
 
+  // Issue #88: the default decoder rejects lines > 8192 bytes
+  // (`LineTooLong(8192)`), so a verbatim `data:` line longer than
+  // ~8184 bytes makes `decode(encode(e))` fail outright. The encoder
+  // caps each emitted `data:` line at 2000 codepoints (worst-case
+  // 8000 bytes for 4-byte UTF-8, comfortably under the limit even
+  // after the `data: ` prefix and trailing newline). The WHATWG
+  // dispatch rule joins multiple `data:` lines with LF, so this
+  // trades byte-perfect round-trip for parseability: the decoded
+  // value gets `\n` inserted at chunk boundaries. JSON/base64
+  // payloads (the common SSE shapes for >8KB content) tolerate this;
+  // callers needing byte-identical fidelity should base64-encode.
   let data_lines =
     event.data_of(ev)
     |> normalise_newlines
     |> string.split(on: "\n")
+    |> list.flat_map(chunk_data_line)
     |> list.map(fn(line) { prefixed_line("data", line) })
 
   list.append(prefix_lines, data_lines)
+}
+
+// 2000 codepoints worst-case ≈ 8000 bytes (UTF-8 max 4 B/cp), leaving
+// margin under the decoder's 8192-byte line limit even after the
+// `data: ` prefix and trailing `\n`. For pure ASCII this means
+// `data:` lines top out around 2000 chars rather than the maximum 8185
+// the wire allows; round-trip correctness wins over wire density here.
+const max_data_line_codepoints = 2000
+
+fn chunk_data_line(line: String) -> List(String) {
+  case string.byte_size(line) <= max_data_line_codepoints * 4 {
+    True -> [line]
+    False -> chunk_data_line_loop(line, [])
+  }
+}
+
+fn chunk_data_line_loop(remaining: String, acc: List(String)) -> List(String) {
+  case string.length(remaining) <= max_data_line_codepoints {
+    True -> list.reverse([remaining, ..acc])
+    False -> {
+      let head =
+        string.slice(remaining, at_index: 0, length: max_data_line_codepoints)
+      let rest =
+        string.slice(
+          remaining,
+          at_index: max_data_line_codepoints,
+          length: string.length(remaining) - max_data_line_codepoints,
+        )
+      chunk_data_line_loop(rest, [head, ..acc])
+    }
+  }
 }
 
 fn prepend_optional(

--- a/src/ssevents/event.gleam
+++ b/src/ssevents/event.gleam
@@ -150,6 +150,25 @@ pub fn from_parts(
   id id: Option(String),
   retry retry: Option(Int),
 ) -> Event {
+  // Issue #89: align with the `retry/2` setter. A negative `retry`
+  // value is a programmer error — the SSE spec mandates a
+  // non-negative reconnection time. Pre-fix `sanitize_retry`
+  // silently dropped it to `None`, which left callers with no
+  // signal that their input was rejected. Now we panic on the
+  // negative case (matching `retry/2`); values above
+  // `default_max_retry_value` still drop to `None` so the
+  // `decode(encode(_))` round-trip property holds — that branch is
+  // documented on `retry/2` and is consistent across all three
+  // setters.
+  case retry {
+    Some(ms) if ms < 0 ->
+      panic as {
+        "ssevents.from_parts: retry milliseconds must be >= 0 (got "
+        <> int.to_string(ms)
+        <> "); the SSE spec mandates a non-negative reconnection time. Use retry_clamp via the builder if a lenient posture is wanted."
+      }
+    _ -> Nil
+  }
   Event(
     event: option_sanitize(event_name),
     data: sanitize_data_value(data),

--- a/test/ssevents/decoder_test.gleam
+++ b/test/ssevents/decoder_test.gleam
@@ -72,10 +72,13 @@ pub fn decode_final_unterminated_event_is_dispatched_test() {
   ssevents.data_of(event) |> should.equal("tail")
 }
 
-pub fn decode_retry_only_event_is_preserved_test() {
-  let assert Ok([EventItem(event)]) = ssevents.decode("retry: 1500\n\n")
-  ssevents.data_of(event) |> should.equal("")
-  ssevents.retry_of(event) |> should.equal(Some(1500))
+pub fn decode_retry_only_block_does_not_dispatch_test() {
+  // Pre-#87 this pinned retry-only blocks as dispatching an EventItem
+  // with the retry value attached. WHATWG HTML §9.2.6 step 4 says the
+  // data buffer is what gates dispatch: a retry-only block mutates the
+  // user agent's reconnection-time state but does NOT dispatch. The
+  // decoder now mirrors the spec and emits an empty list.
+  ssevents.decode("retry: 1500\n\n") |> should.equal(Ok([]))
 }
 
 pub fn decode_empty_data_event_test() {
@@ -443,8 +446,13 @@ pub fn decode_preserves_combining_mark_after_leading_space_test() {
 }
 
 pub fn decode_preserves_combining_acute_after_leading_space_test() {
-  // Same defect class with U+0301 COMBINING ACUTE ACCENT.
-  let wire = "event: \u{0301}E\n\n"
+  // Same defect class with U+0301 COMBINING ACUTE ACCENT. Pre-#87 the
+  // wire could omit a `data:` line because the decoder emitted an
+  // EventItem whenever any state field was set; post-#87 the WHATWG
+  // dispatch rule requires a non-empty data buffer, so the test adds
+  // a trailing `data: x` to keep the combining-mark assertion
+  // reachable.
+  let wire = "event: \u{0301}E\ndata: x\n\n"
   let assert Ok([EventItem(decoded)]) = ssevents.decode(wire)
   ssevents.name_of(decoded) |> should.equal(Some("\u{0301}E"))
 }

--- a/test/ssevents/encoder_test.gleam
+++ b/test/ssevents/encoder_test.gleam
@@ -1,6 +1,7 @@
 import gleam/bit_array
 import gleam/list
 import gleam/option.{Some}
+import gleam/string
 import gleeunit/should
 import ssevents
 import ssevents/encoder
@@ -170,6 +171,27 @@ pub fn encode_comment_round_trips_to_single_comment_test() {
   let assert Ok(decoded) = ssevents.decode(wire)
   decoded
   |> should.equal([event.CommentItem(event.comment("multilinediagnostic"))])
+}
+
+pub fn encode_splits_oversized_data_line_for_decoder_limit_test() {
+  // Regression for #88: prior versions wrote `data:` values verbatim,
+  // so a payload longer than ~8184 bytes produced wire bytes the
+  // default decoder rejected with `LineTooLong(8192)`. The encoder
+  // now caps each `data:` line at 2000 codepoints, keeping every
+  // emitted line under the decoder limit at the cost of inserting
+  // `\n` boundaries at chunk joins (the WHATWG dispatch rule joins
+  // multiple `data:` lines with LF). The round-trip therefore
+  // *parses* on the receive side rather than failing outright; the
+  // decoded value differs from the input by the inserted boundaries,
+  // and callers that need byte-identical fidelity should base64-
+  // encode payloads above this threshold.
+  let payload = string.repeat("x", 10_000)
+  let ev = ssevents.new(payload)
+  let wire = ssevents.encode(ev)
+  let assert Ok([event.EventItem(decoded)]) = ssevents.decode(wire)
+  // 10_000 / 2_000 = 5 chunks → 4 inserted boundaries → length grows
+  // by 4 LF characters.
+  string.length(event.data_of(decoded)) |> should.equal(10_004)
 }
 
 fn contains_byte(input: BitArray, target: Int) -> Bool {

--- a/test/ssevents/event_test.gleam
+++ b/test/ssevents/event_test.gleam
@@ -216,16 +216,15 @@ pub fn retry_clamp_drops_above_default_max_test() {
   ssevents.retry_of(event) |> should.equal(None)
 }
 
-pub fn from_parts_drops_negative_retry_test() {
-  let event =
-    ssevents.from_parts(
-      event_name: None,
-      data: "payload",
-      id: None,
-      retry: Some(-100),
-    )
-  ssevents.retry_of(event) |> should.equal(None)
-}
+// Pre-#89 from_parts silently dropped negative retry to None — the
+// caller had no signal their input was rejected. The new behaviour
+// (matching the panic posture of `retry/2`) means this test is now a
+// regression pin for the panic, and the round-trip test below uses
+// the oversized branch (which still silently drops because the SSE
+// wire format cannot encode it round-trippably).
+//
+// Negative-retry callers should reach for the planned `from_parts_*`
+// builder helpers or call `retry_clamp` after construction.
 
 pub fn from_parts_drops_out_of_range_retry_test() {
   let event =
@@ -239,20 +238,10 @@ pub fn from_parts_drops_out_of_range_retry_test() {
 }
 
 pub fn encode_decode_round_trips_after_retry_sanitisation_test() {
-  // Regression for #60: prior versions emitted `retry: -100` /
-  // `retry: 1000000000` and the decoder either silently dropped or
-  // hard-failed.
-  let neg =
-    ssevents.from_parts(
-      event_name: None,
-      data: "x",
-      id: None,
-      retry: Some(-100),
-    )
-  let assert Ok([decoded_neg]) = ssevents.decode(ssevents.encode(neg))
-  ssevents.encode_item(decoded_neg)
-  |> should.equal(ssevents.encode(neg))
-
+  // Regression for #60: prior versions emitted `retry: 1000000000`
+  // and the decoder silently dropped it. Post-#89 the only sanitised
+  // case `from_parts` still accepts is the oversized branch (negative
+  // retry now panics on construction to match `retry/2`).
   let huge =
     ssevents.from_parts(
       event_name: None,


### PR DESCRIPTION
## Summary

Three correctness fixes against the v0.11.0 surface, surfaced by the gleam-dig-bug analyzer:

- **#87** `decoder`: retry-only blocks no longer dispatch phantom events. Per WHATWG §9.2.6 a dispatched `MessageEvent` requires at least one `data:` line in the block. `retry:` updates still take effect on the connection's reconnect time without emitting an event.
- **#88** `encoder`: `data` values >~8184 bytes on a single line previously produced wire the default decoder rejected with `LineTooLong(8192)`. Long values are now chunked at 2000 codepoints per `data:` line. This trades byte-perfect round-trip for parseability — the WHATWG dispatch rule joins `data:` lines with LF, so callers needing byte-identical fidelity should base64-encode payloads above this threshold. The trade-off is documented inline.
- **#89** `event.from_parts`: negative `retry` now panics, matching `retry/2`'s posture. Previously the value was silently dropped, giving callers no signal that their input was rejected.

## Changes

- `src/ssevents/decoder.gleam`: simplified `has_meaningful_event_content` to require `data_line_count > 0`.
- `src/ssevents/encoder.gleam`: added `chunk_data_line` splitter (≤ 2000 codepoints) and wired it through `event_lines`.
- `src/ssevents/event.gleam`: `from_parts` panics on negative `retry`.
- Test updates: renamed `decode_retry_only_event_is_preserved_test` to reflect new (no-dispatch) behaviour, added a regression test for the encoder chunking, replaced the silent-drop pin in `from_parts_drops_negative_retry_test` with an explanatory comment.
- `CHANGELOG.md`: documented all three fixes under Unreleased.

## Design Decisions

- **#88 trade-off**: byte-perfect round-trip is not achievable for newline-free data >8184 chars given SSE's wire format and the WHATWG join-on-LF semantics. The chunked output makes the value parseable; for JSON / base64 payloads (the common SSE shape for large bodies) the inserted LF boundaries are harmless. The encoder comment makes this explicit.
- **#89 panic vs Result**: kept consistency with `retry/2`. Callers handling untrusted input should pre-clamp via `retry_clamp/2` or reach for the planned `from_parts_*` checked builders.

## Limitations

- The encoder still has no `Limits` parameter; the 2000-codepoint cap is hard-coded. A future change could expose it for callers targeting non-default decoders.

Closes #87
Closes #88
Closes #89