### PR TITLE
chore(release): prepare v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-11
+
 ### Fixed
 
 - **`ssevents/decoder`**: a block containing only a `retry:` field no

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "ssevents"
-version = "0.11.0"
+version = "0.12.0"
 description = "Server-Sent Events primitives for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "ssevents" }


### PR DESCRIPTION
## Summary

Prepare release v0.12.0. Patch-level fixes that change observable behaviour at the dispatch boundary, so promoting to a minor bump.

## Changes

- `gleam.toml`: 0.11.0 → 0.12.0
- `CHANGELOG.md`: section header for 0.12.0 with 2026-05-11

## Bundled fixes

- #87 decoder retry-only block no longer dispatches a phantom event
- #88 encoder caps `data:` lines at 2000 codepoints to stay under the default decoder line limit
- #89 `event.from_parts` panics on negative `retry`, matching `retry/2`