### PR TITLE
docs(readme): note retry_clamp also silently drops > 24h to None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Documentation
+
+- README's `retry_clamp/2` paragraph now states both silent transformations: negative values are rounded up to `0`, **and** values above the 24 h cap (`limit.default_max_retry_value`) are silently dropped to `None`. The function docstring already documented the upper-bound drop; the README only mentioned the negative-side clamp, so a caller reading just the README who forwarded truly noisy input would silently emit events without any `retry:` line on the wire. (#92)
+
 ## [0.12.0] - 2026-05-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ pub fn encode_example() -> BitArray {
 > contract-violating wire. If the value comes from untrusted input
 > (a request field, a deserialised config, a CLI flag), reach for
 > `ssevents.retry_clamp/2` — it silently rounds negative values up
-> to `0` and is otherwise identical. Same posture applies if the
+> to `0` *and silently drops values above the 24 h cap
+> (`limit.default_max_retry_value`) to `None`*, so callers forwarding
+> truly noisy input must accept that out-of-range values vanish from
+> the wire rather than produce a `retry:` line. The drop matches
+> `retry/2`'s and `from_parts/4`'s behaviour at that boundary so the
+> default decoder round-trips. Same posture applies if the
 > name / id / comment text comes from untrusted input: prefer the
 > `*_checked` variants (`event_checked`, `id_checked`,
 > `named_checked`, `comment_checked`) so CR / LF / NUL bytes


### PR DESCRIPTION
## Summary

The README's `retry_clamp/2` paragraph framed the function as \"silently rounds negative values up to `0` and is otherwise identical [to `retry/2`]\", which gave the impression that the negative-side clamp was the only silent transformation. In practice, `retry_clamp/2` also silently drops values above `limit.default_max_retry_value` (24 h in milliseconds) to `None`, exactly like `retry/2` and `from_parts/4`. The function docstring already documented this; the README did not. A caller who reads only the README and forwards a \"possibly-noisy input\" (the use case the README itself recommends `retry_clamp` for) can emit events without any `retry:` line on the wire, silently.

## Changes

- [README.md](README.md) The `retry_clamp/2` paragraph now spells out both silent transformations: negative → 0, and \"above the 24 h cap (`limit.default_max_retry_value`) → `None`\". The drop is also justified inline (round-trip with the default decoder, parity with `retry/2` / `from_parts/4`).
- [CHANGELOG.md](CHANGELOG.md) Unreleased Documentation entry.

Closes #92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for retry value processing behavior. Explained how edge case values—negative numbers and those exceeding the maximum timeout limit—are silently transformed to ensure callers understand all boundary conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nao1215/ssevents/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->