### PR TITLE
chore(release): prepare v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-05-18
+
 ### Documentation
 
 - README's `retry_clamp/2` paragraph now states both silent transformations: negative values are rounded up to `0`, **and** values above the 24 h cap (`limit.default_max_retry_value`) are silently dropped to `None`. The function docstring already documented the upper-bound drop; the README only mentioned the negative-side clamp, so a caller reading just the README who forwarded truly noisy input would silently emit events without any `retry:` line on the wire. (#92)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "ssevents"
-version = "0.12.0"
+version = "0.13.0"
 description = "Server-Sent Events primitives for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "ssevents" }


### PR DESCRIPTION
### Documentation

- README's `retry_clamp/2` paragraph now states both silent transformations: negative values are rounded up to `0`, **and** values above the 24 h cap (`limit.default_max_retry_value`) are silently dropped to `None`. The function docstring already documented the upper-bound drop; the README only mentioned the negative-side clamp, so a caller reading just the README who forwarded truly noisy input would silently emit events without any `retry:` line on the wire. (#92)
