### PR TITLE
fix(decoder): silent drop on retry > cap, opt-in strict via with_strict_retry_cap (#95)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking — `ssevents/decoder`**: `retry:` values whose integer form exceeds `limit.default_max_retry_value` (24 h in ms) no longer fail the whole stream with `Error(InvalidRetry(_))`. The decoder now silently drops the offending field to `None` and the surrounding event still dispatches — symmetric with the encoder's `retry_clamp/2` and matching WHATWG SSE's lenient parser thesis. A single hostile `retry: 99999999999999` can no longer knock out the rest of the stream. Callers that need to detect such overruns explicitly can opt back into the strict posture via `ssevents.with_strict_retry_cap(limits, True)`. (#95)
+
+### Added
+
+- **`ssevents` / `ssevents/limit`**: `with_strict_retry_cap/2` and `strict_retry_cap/1`. Opt back into the pre-0.14 strict posture where `retry:` values above `max_retry_value` fail the whole decode. The default stays lenient. (#95)
+
 ## [0.13.0] - 2026-05-18
 
 ### Documentation

--- a/src/ssevents.gleam
+++ b/src/ssevents.gleam
@@ -379,6 +379,30 @@ pub fn max_retry_value(limits: Limits) -> Int {
   limit.max_retry_value(limits)
 }
 
+/// Read the `strict_retry_cap` flag from a `Limits` value.
+///
+/// When `True`, the decoder errors with `InvalidRetry(_)` on
+/// `retry:` values above `max_retry_value`. When `False` (the
+/// default), the decoder silently drops the offending field to
+/// `None` and the surrounding event still dispatches. (#95)
+pub fn strict_retry_cap(limits: Limits) -> Bool {
+  limit.strict_retry_cap(limits)
+}
+
+/// Toggle the decoder's `retry:` cap-overrun posture.
+///
+/// `False` (the default) keeps the decoder lenient: a `retry:` value
+/// above `max_retry_value` is silently dropped to `None` and the
+/// surrounding event still dispatches, mirroring the encoder's
+/// `retry_clamp/2` and matching WHATWG SSE's lenient parser thesis.
+/// `True` re-enables the strict posture: an above-cap value fails
+/// the whole decode with `Error(InvalidRetry(_))`, so callers that
+/// want to detect adversarial retry values explicitly can do so.
+/// (#95)
+pub fn with_strict_retry_cap(limits: Limits, strict: Bool) -> Limits {
+  limit.with_strict_retry_cap(limits, strict)
+}
+
 pub fn validate_event_name(name: String) -> Result(String, SseError) {
   validate.validate_event_name(name)
 }

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -5,8 +5,11 @@
 //// - unknown fields are ignored
 //// - EOF dispatches the final unterminated event or trailing comment
 //// - the first decode error fails the whole operation
-//// - retry values must be ASCII digits and must not exceed
-////   `Limits.max_retry_value`
+//// - retry values must be ASCII digits; values above
+////   `Limits.max_retry_value` are silently dropped to `None`
+////   (symmetric with `event.retry_clamp/2`) unless
+////   `Limits.strict_retry_cap` is set, in which case they fail with
+////   `InvalidRetry(_)` (#95)
 
 import gleam/bit_array
 import gleam/int
@@ -289,18 +292,17 @@ fn apply_field_parts(
           // field silently when the value isn't all ASCII digits
           // (negative `-100`, decimal `12.5`, empty, etc.). Values
           // that *are* all digits but exceed `max_retry_value` are
-          // still surfaced as `Error(InvalidRetry(_))` because that
-          // limit is a per-decoder safety bound, not a spec rule.
+          // also silently dropped to `None` by default — this matches
+          // the encoder's `retry_clamp/2` posture so the
+          // `decode(encode(_))` round-trip survives the cap, and
+          // prevents a single adversarial `retry: 99999999999` from
+          // failing the whole stream. Callers that need to detect
+          // such overruns explicitly can opt in via
+          // `limit.with_strict_retry_cap(_, True)`. (#95)
           case is_ascii_digit_string(value) {
             False ->
               Ok(#(DecodeState(..state, event_bytes: next_event_bytes), []))
-            True ->
-              apply_validated_field(
-                state,
-                parse_retry(value, state.limits),
-                next_event_bytes,
-                fn(s, v) { DecodeState(..s, retry: Some(v)) },
-              )
+            True -> apply_retry_field(state, value, next_event_bytes)
           }
         _ -> Ok(#(DecodeState(..state, event_bytes: next_event_bytes), []))
       }
@@ -473,17 +475,51 @@ fn decode_comment_text(value: String) -> String {
   trim_optional_leading_space(value)
 }
 
-fn parse_retry(value: String, limits: limit.Limits) -> Result(Int, SseError) {
-  case is_ascii_digit_string(value) {
-    False -> Error(InvalidRetry(value))
-    True ->
-      case int.parse(value) {
-        Error(_) -> Error(InvalidRetry(value))
-        Ok(parsed) ->
-          case parsed > limit.max_retry_value(limits) {
+/// Apply a `retry:` field whose value is already known to be an
+/// all-ASCII-digit string (the digits-only filter ran in the caller).
+///
+/// The branch table here is the heart of the lenient-by-default
+/// retry-cap behaviour pinned in #95:
+/// - parse failure on an all-digit value would only happen for an
+///   integer literal that overflows the platform `Int`. Treat it the
+///   same as a cap overrun (silent drop, or `InvalidRetry` under
+///   strict mode) so the surrounding event still dispatches.
+/// - all-digit values that are within the cap are accepted as-is.
+/// - all-digit values above `max_retry_value` are silently dropped to
+///   `None` by default (symmetric with `event.retry_clamp/2`), and
+///   surface as `InvalidRetry(_)` only when
+///   `limit.strict_retry_cap(limits)` is `True`.
+fn apply_retry_field(
+  state: DecodeState,
+  value: String,
+  next_event_bytes: Int,
+) -> Result(#(DecodeState, List(event.Item)), SseError) {
+  let dropped = #(DecodeState(..state, event_bytes: next_event_bytes), [])
+  let strict = limit.strict_retry_cap(state.limits)
+  case int.parse(value) {
+    Error(_) ->
+      case strict {
+        True -> Error(InvalidRetry(value))
+        False -> Ok(dropped)
+      }
+    Ok(parsed) ->
+      case parsed > limit.max_retry_value(state.limits) {
+        True ->
+          case strict {
             True -> Error(InvalidRetry(value))
-            False -> Ok(parsed)
+            False -> Ok(dropped)
           }
+        False ->
+          Ok(
+            #(
+              DecodeState(
+                ..state,
+                event_bytes: next_event_bytes,
+                retry: Some(parsed),
+              ),
+              [],
+            ),
+          )
       }
   }
 }

--- a/src/ssevents/limit.gleam
+++ b/src/ssevents/limit.gleam
@@ -16,6 +16,13 @@ pub opaque type Limits {
     max_event_bytes: Int,
     max_data_lines: Int,
     max_retry_value: Int,
+    /// When `True`, the decoder surfaces `Error(InvalidRetry(_))` for
+    /// `retry:` values whose integer form is above `max_retry_value`.
+    /// When `False` (the default), the decoder silently drops the
+    /// offending `retry:` field to `None` and the surrounding event
+    /// still dispatches — mirroring the encoder's `retry_clamp/2`
+    /// posture and WHATWG SSE's "lenient parser" thesis (#95).
+    strict_retry_cap: Bool,
   )
 }
 
@@ -42,6 +49,7 @@ pub fn default() -> Limits {
     max_event_bytes: default_max_event_bytes,
     max_data_lines: default_max_data_lines,
     max_retry_value: default_max_retry_value,
+    strict_retry_cap: False,
   )
 }
 
@@ -72,6 +80,7 @@ pub fn new(
     max_event_bytes: max_event_bytes,
     max_data_lines: max_data_lines,
     max_retry_value: max_retry_value,
+    strict_retry_cap: False,
   )
 }
 
@@ -93,6 +102,29 @@ pub fn max_data_lines(limits: Limits) -> Int {
 pub fn max_retry_value(limits: Limits) -> Int {
   let Limits(max_retry_value:, ..) = limits
   max_retry_value
+}
+
+/// Read the `strict_retry_cap` flag from a `Limits` value.
+///
+/// When `True`, the decoder errors with `InvalidRetry(_)` on `retry:`
+/// values above `max_retry_value`; when `False` (the default), it
+/// silently drops the offending field to `None` and the surrounding
+/// event still dispatches. See `with_strict_retry_cap/2`. (#95)
+pub fn strict_retry_cap(limits: Limits) -> Bool {
+  let Limits(strict_retry_cap:, ..) = limits
+  strict_retry_cap
+}
+
+/// Toggle the decoder's `retry:` cap-overrun posture.
+///
+/// Defaults to `False` (lenient): a `retry:` value whose integer form
+/// exceeds `max_retry_value` is silently dropped to `None` so the
+/// surrounding event still dispatches, mirroring the encoder's
+/// `retry_clamp/2` and matching WHATWG SSE's lenient parser thesis.
+/// Opt into `True` when downstream code needs to detect adversarial
+/// retry values explicitly. (#95)
+pub fn with_strict_retry_cap(limits: Limits, strict: Bool) -> Limits {
+  Limits(..limits, strict_retry_cap: strict)
 }
 
 /// Like `new`, but returns the argument-validation failure as a
@@ -118,6 +150,7 @@ pub fn new_checked(
     max_event_bytes: max_event_bytes,
     max_data_lines: max_data_lines,
     max_retry_value: max_retry_value,
+    strict_retry_cap: False,
   ))
 }
 

--- a/test/ssevents/decoder_test.gleam
+++ b/test/ssevents/decoder_test.gleam
@@ -340,12 +340,17 @@ pub fn decode_retry_within_limit_still_set_test() {
   ssevents.retry_of(event) |> should.equal(Some(1500))
 }
 
-pub fn decode_retry_above_limit_still_errors_test() {
+pub fn decode_retry_above_limit_under_strict_mode_errors_test() {
   // The `max_retry_value` safety bound is a per-decoder limit, not a
-  // spec rule. Above-limit values stay an `InvalidRetry` error so
-  // callers can detect adversarial input. The default limit is
-  // 86_400_000 ms (one day); 99_999_999_999 is well above.
-  ssevents.decode_bytes(<<"retry: 99999999999\ndata: ping\n\n":utf8>>)
+  // spec rule. Under `with_strict_retry_cap(_, True)` an above-limit
+  // value still surfaces as `InvalidRetry(_)` so callers that need
+  // to detect adversarial input can opt in. The default limit is
+  // 86_400_000 ms (one day); 99_999_999_999 is well above. (#95)
+  let limits = ssevents.default_limits() |> ssevents.with_strict_retry_cap(True)
+  ssevents.decode_bytes_with_limits(
+    <<"retry: 99999999999\ndata: ping\n\n":utf8>>,
+    limits: limits,
+  )
   |> should.equal(Error(InvalidRetry("99999999999")))
 }
 

--- a/test/ssevents/regression_decode_retry_over_cap_test.gleam
+++ b/test/ssevents/regression_decode_retry_over_cap_test.gleam
@@ -1,0 +1,112 @@
+//// Regression coverage for #95.
+////
+//// Pre-#95 the decoder failed the whole stream with
+//// `Error(InvalidRetry(_))` whenever a `retry:` value exceeded the
+//// 24h cap (`limit.default_max_retry_value`). That was asymmetric
+//// with the encoder's `retry_clamp/2`, which silently dropped such
+//// values to `None`, and a single hostile `retry: 99999999999999`
+//// could knock out the rest of the stream.
+////
+//// Post-#95 the decoder is lenient by default — above-cap values
+//// drop to `None` and the surrounding event still dispatches. The
+//// strict (cap-overrun = `Error`) posture remains available through
+//// `limit.with_strict_retry_cap(_, True)`.
+
+import gleam/list
+import gleam/option.{None, Some}
+import gleeunit/should
+import ssevents
+import ssevents/error.{InvalidRetry}
+
+// === Lenient default — retry over the cap silently drops ===
+
+pub fn decode_with_retry_over_24h_still_returns_event_test() {
+  let assert Ok([item]) = ssevents.decode("retry: 86400001\ndata: x\n\n")
+  let assert Some(ev) = ssevents.event_of_item(item)
+  ssevents.data_of(ev) |> should.equal("x")
+  // 24h + 1ms is above `default_max_retry_value` (86_400_000); the
+  // lenient default drops the retry field to `None` rather than
+  // failing the whole stream.
+  ssevents.retry_of(ev) |> should.equal(None)
+}
+
+pub fn decode_with_huge_retry_still_returns_event_test() {
+  let assert Ok([item]) = ssevents.decode("retry: 99999999999999\ndata: x\n\n")
+  let assert Some(ev) = ssevents.event_of_item(item)
+  ssevents.data_of(ev) |> should.equal("x")
+  ssevents.retry_of(ev) |> should.equal(None)
+}
+
+pub fn decode_multiple_events_with_one_bad_retry_test() {
+  // The original repro: an early event has a 1e13-ms retry. Pre-#95
+  // the rest of the stream was unreachable; post-#95 the first
+  // event's retry drops to `None` and the later events still
+  // dispatch.
+  let wire = "retry: 99999999999999\ndata: a\n\ndata: b\n\ndata: c\n\n"
+  let assert Ok(items) = ssevents.decode(wire)
+  list.length(items) |> should.equal(3)
+  // Spot-check that the data payloads survived the cap-overrun.
+  let datas =
+    items
+    |> list.filter_map(fn(item) {
+      case ssevents.event_of_item(item) {
+        Some(ev) -> Ok(ssevents.data_of(ev))
+        None -> Error(Nil)
+      }
+    })
+  datas |> should.equal(["a", "b", "c"])
+}
+
+// === Regression for the still-working baseline ===
+
+pub fn decode_retry_at_24h_cap_test() {
+  let assert Ok([item]) = ssevents.decode("retry: 86400000\ndata: x\n\n")
+  let assert Some(ev) = ssevents.event_of_item(item)
+  ssevents.retry_of(ev) |> should.equal(Some(86_400_000))
+}
+
+pub fn decode_normal_retry_test() {
+  let assert Ok([item]) = ssevents.decode("retry: 5000\ndata: x\n\n")
+  let assert Some(ev) = ssevents.event_of_item(item)
+  ssevents.retry_of(ev) |> should.equal(Some(5000))
+}
+
+pub fn encode_decode_retry_clamp_symmetry_test() {
+  // Encoder side: `retry_clamp(_, 1e13)` silently maps to `None`
+  // (see `event.sanitize_retry`). Post-#95 the decoder mirrors that
+  // posture, so the two ends of the wire agree.
+  let event = ssevents.new("x") |> ssevents.retry_clamp(99_999_999_999_999)
+  ssevents.retry_of(event) |> should.equal(None)
+}
+
+// === Strict opt-in still surfaces the cap overrun as an error ===
+
+pub fn decode_with_strict_retry_cap_above_limit_errors_test() {
+  let limits = ssevents.default_limits() |> ssevents.with_strict_retry_cap(True)
+  ssevents.decode_with_limits(
+    "retry: 99999999999999\ndata: x\n\n",
+    limits: limits,
+  )
+  |> should.equal(Error(InvalidRetry("99999999999999")))
+}
+
+pub fn decode_with_strict_retry_cap_at_cap_still_ok_test() {
+  // Strict mode only flips the *over*-the-cap branch — the at-cap
+  // value is still accepted.
+  let limits = ssevents.default_limits() |> ssevents.with_strict_retry_cap(True)
+  let assert Ok([item]) =
+    ssevents.decode_with_limits("retry: 86400000\ndata: x\n\n", limits: limits)
+  let assert Some(ev) = ssevents.event_of_item(item)
+  ssevents.retry_of(ev) |> should.equal(Some(86_400_000))
+}
+
+pub fn default_limits_strict_retry_cap_is_false_test() {
+  ssevents.default_limits() |> ssevents.strict_retry_cap |> should.equal(False)
+}
+
+pub fn with_strict_retry_cap_true_flips_flag_test() {
+  ssevents.default_limits()
+  |> ssevents.with_strict_retry_cap(True)
+  |> ssevents.strict_retry_cap
+  |> should.equal(True)
+}


### PR DESCRIPTION
## Summary

Pre-#95 `ssevents.decode` failed the whole stream with `Error(InvalidRetry(_))` whenever a `retry:` value exceeded `limit.default_max_retry_value` (24h in ms). That was asymmetric with the encoder's `retry_clamp/2`, which silently dropped such values to `None`, and a single hostile `retry: 99999999999999` could knock out every later event in the stream.

The decoder is now **lenient by default**: above-cap retry values drop to `None` and the surrounding event still dispatches, mirroring `retry_clamp/2` and matching WHATWG SSE's lenient parser thesis. Callers that need to detect adversarial retry values explicitly can opt back into the pre-0.14 strict posture via `ssevents.with_strict_retry_cap(limits, True)`.

## Changes

- **Breaking** — `src/ssevents/decoder.gleam`: `retry:` values whose integer form exceeds `max_retry_value` no longer error. They drop the field silently to `None` and the surrounding event still dispatches.
- `src/ssevents/limit.gleam`: `Limits` gains a `strict_retry_cap` flag (default `False`). New helpers `strict_retry_cap/1` getter and `with_strict_retry_cap/2` setter.
- `src/ssevents.gleam`: re-export `strict_retry_cap` and `with_strict_retry_cap` through the canonical facade.
- `test/ssevents/regression_decode_retry_over_cap_test.gleam`: 10 new cases covering lenient default + strict opt-in + cap boundary + encode/decode symmetry.
- `test/ssevents/decoder_test.gleam`: pre-existing `decode_retry_above_limit_still_errors_test` updated to assert the strict-mode behaviour under `with_strict_retry_cap(True)`, matching the new default.
- `CHANGELOG.md`: `### Changed` (Breaking notice) + `### Added` under `[Unreleased]`.

## Test plan

- [x] `just all` green (`gleam format --check`, `gleam check`, `glinter`, build erlang/javascript, test erlang/javascript, docs, examples)
- [x] 183 tests pass on both targets
- [x] All three runnable examples (`quick_start`, `streaming_consume`, `server_emit`) still run

Closes #95