### PR TITLE
feat(limit): add with_max_event_size to relax decoder per-event cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 
 - **`ssevents` / `ssevents/limit`**: `with_strict_retry_cap/2` and `strict_retry_cap/1`. Opt back into the pre-0.14 strict posture where `retry:` values above `max_retry_value` fail the whole decode. The default stays lenient. (#95)
+- **`ssevents` / `ssevents/limit`**: `with_max_event_size/2` and `max_event_size/1`. Raise the decoder's per-event byte cap so caller-trusted oversize events round-trip through `decode_with_limits` instead of failing the whole stream with `Error(EventTooLarge(65_536))`; the default `decode/1` keeps the 65_536-byte safety net. (#96)
 
 ## [0.13.0] - 2026-05-18
 

--- a/src/ssevents.gleam
+++ b/src/ssevents.gleam
@@ -371,6 +371,37 @@ pub fn max_event_bytes(limits: Limits) -> Int {
   limit.max_event_bytes(limits)
 }
 
+/// Alias of `max_event_bytes/1`. Pairs with `with_max_event_size/2`
+/// so callers that raise the per-event cap can read it back using the
+/// same spelling. (#96)
+pub fn max_event_size(limits: Limits) -> Int {
+  limit.max_event_size(limits)
+}
+
+/// Override the per-event byte cap on a `Limits` value.
+///
+/// The default decoder (`decode/1`, `decode_bytes/1`) runs with a
+/// 65_536-byte cap and fails the whole stream with
+/// `Error(EventTooLarge(65_536))` for any event above that. The
+/// encoder never rejects an event for sheer size, so a 100 KB event
+/// the package's own encoder produced would be unreachable on the
+/// decode side without this override. Pair with `decode_with_limits`
+/// (or `decode_bytes_with_limits`) to raise the cap:
+///
+/// ```gleam
+/// let limits =
+///   ssevents.default_limits()
+///   |> ssevents.with_max_event_size(200_000)
+/// ssevents.decode_with_limits(wire, limits: limits)
+/// ```
+///
+/// The default `decode/1` keeps the 65_536-byte ceiling as a
+/// memory-bound safety net for untrusted input. Panics on
+/// `bytes < 1`. (#96)
+pub fn with_max_event_size(limits: Limits, bytes: Int) -> Limits {
+  limit.with_max_event_size(limits, bytes)
+}
+
 pub fn max_data_lines(limits: Limits) -> Int {
   limit.max_data_lines(limits)
 }

--- a/src/ssevents/decoder.gleam
+++ b/src/ssevents/decoder.gleam
@@ -43,10 +43,25 @@ pub opaque type DecodeState {
   )
 }
 
+/// Decode a full SSE wire-format `String` into the list of `Item`s it
+/// represents.
+///
+/// Runs with `limit.default()`, whose per-event cap is
+/// `default_max_event_bytes` (65_536 bytes). Any single event larger
+/// than that fails the whole decode with `Error(EventTooLarge(65_536))`
+/// — note this is asymmetric with the encoder, which never rejects an
+/// event for sheer size. Callers that knowingly round-trip events
+/// above 65_536 bytes (e.g. 100 KB JSON payloads emitted by their own
+/// encoder) must raise the cap via
+/// `decode_with_limits(wire, limit.default()
+/// |> limit.with_max_event_size(200_000))`. (#96)
 pub fn decode(input: String) -> Result(List(event.Item), SseError) {
   decode_with_limits(input, limits: limit.default())
 }
 
+/// `BitArray` counterpart of `decode/1`. Same default per-event cap of
+/// 65_536 bytes; reach for `decode_bytes_with_limits` with
+/// `limit.with_max_event_size/2` to raise it. (#96)
 pub fn decode_bytes(input: BitArray) -> Result(List(event.Item), SseError) {
   decode_bytes_with_limits(input, limits: limit.default())
 }

--- a/src/ssevents/limit.gleam
+++ b/src/ssevents/limit.gleam
@@ -127,6 +127,45 @@ pub fn with_strict_retry_cap(limits: Limits, strict: Bool) -> Limits {
   Limits(..limits, strict_retry_cap: strict)
 }
 
+/// Alias of `max_event_bytes/1`. Reads the per-event byte cap the
+/// decoder uses to reject oversize events with
+/// `Error(EventTooLarge(_))`. Provided so callers can stay in the
+/// `with_max_event_size` / `max_event_size` spelling pair when
+/// raising the limit explicitly. (#96)
+pub fn max_event_size(limits: Limits) -> Int {
+  max_event_bytes(limits)
+}
+
+/// Override the per-event byte cap on a `Limits` value.
+///
+/// `ssevents.decode/1` runs with `default_max_event_bytes` (65_536) and
+/// fails the whole stream with `Error(EventTooLarge(65_536))` for any
+/// event above that cap — symmetric with `max_line_bytes` /
+/// `max_data_lines`, but asymmetric with the encoder side which never
+/// rejects an event for sheer size. A caller that knowingly emits a
+/// 100 KB event and pipes it back through the decoder needs to raise
+/// the cap explicitly:
+///
+/// ```gleam
+/// let limits =
+///   ssevents.default_limits()
+///   |> ssevents.with_max_event_size(200_000)
+/// ssevents.decode_with_limits(wire, limits: limits)
+/// ```
+///
+/// The default `decode/1` deliberately keeps the 65_536-byte ceiling
+/// as a memory-bound safety net for untrusted input; reach for
+/// `decode_with_limits` + `with_max_event_size` when the input is
+/// trusted and known to be larger. Panics on `bytes < 1` to mirror
+/// `new/4`'s posture. (#96)
+pub fn with_max_event_size(limits: Limits, bytes: Int) -> Limits {
+  case bytes < 1 {
+    True -> panic as "max_event_size must be >= 1"
+    False -> Nil
+  }
+  Limits(..limits, max_event_bytes: bytes)
+}
+
 /// Like `new`, but returns the argument-validation failure as a
 /// `Result` instead of panicking. Use this when limit values come
 /// from configuration, environment variables, or other dynamic

--- a/test/ssevents/regression_event_too_large_test.gleam
+++ b/test/ssevents/regression_event_too_large_test.gleam
@@ -1,0 +1,138 @@
+//// Regression coverage for #96.
+////
+//// Pre-#96 `ssevents.decode(wire)` failed the whole stream with a
+//// hardcoded `Error(EventTooLarge(65_536))` whenever a single event
+//// exceeded 65_536 bytes. The encoder side never rejected an event
+//// for sheer size, so a 100 KB event produced by the package's own
+//// `encode_item` was unreachable on the decode side and could knock
+//// out every later event in the same wire.
+////
+//// Post-#96 the 65_536-byte cap remains the *default* (memory-bound
+//// safety net for untrusted input), but callers can raise it through
+//// `limit.with_max_event_size/2` and pipe the limits through
+//// `decode_with_limits`.
+
+import gleam/list
+import gleam/option.{Some}
+import gleam/string
+import gleeunit/should
+import ssevents
+import ssevents/error.{EventTooLarge}
+
+// === Raised cap — `decode_with_limits` lets a 100 KB event round-trip ===
+
+pub fn decode_large_event_with_relaxed_limit_test() {
+  // The repro from #96: a 100 KB payload encoded by `encode_item` is
+  // unreachable through `decode/1` under the default 65_536-byte cap.
+  // With `with_max_event_size(200_000)` the wire round-trips. The
+  // encoder chunks long `data:` payloads into ≤ 2000-codepoint lines
+  // (#88), and WHATWG SSE §9.2.6 joins them back with LF on dispatch,
+  // so the decoded data carries embedded `\n` separators — strip them
+  // before comparing the payload.
+  let long_data = string.repeat("x", 100_000)
+  let item = ssevents.new(long_data) |> ssevents.event_item
+  let wire = ssevents.encode_item(item)
+  let lim = ssevents.default_limits() |> ssevents.with_max_event_size(200_000)
+  let assert Ok([decoded]) = ssevents.decode_with_limits(wire, limits: lim)
+  let assert Some(ev) = ssevents.event_of_item(decoded)
+  ev
+  |> ssevents.data_of
+  |> string.replace(each: "\n", with: "")
+  |> should.equal(long_data)
+}
+
+pub fn decode_bytes_large_event_with_relaxed_limit_test() {
+  // BitArray counterpart of the String round-trip above. Same
+  // chunking caveat for the LF separators.
+  let long_data = string.repeat("y", 80_000)
+  let item = ssevents.new(long_data) |> ssevents.event_item
+  let wire = ssevents.encode_item_bytes(item)
+  let lim = ssevents.default_limits() |> ssevents.with_max_event_size(150_000)
+  let assert Ok([decoded]) =
+    ssevents.decode_bytes_with_limits(wire, limits: lim)
+  let assert Some(ev) = ssevents.event_of_item(decoded)
+  ev
+  |> ssevents.data_of
+  |> string.replace(each: "\n", with: "")
+  |> should.equal(long_data)
+}
+
+// === Default behaviour preserved — `decode/1` still rejects oversize ===
+
+pub fn decode_default_limit_still_rejects_oversize_test() {
+  // The 65_536-byte ceiling is a memory-bound safety net for
+  // untrusted input. `decode/1` keeps it; the override is opt-in.
+  let long_data = string.repeat("x", 100_000)
+  let item = ssevents.new(long_data) |> ssevents.event_item
+  let wire = ssevents.encode_item(item)
+  ssevents.decode(wire) |> should.equal(Error(EventTooLarge(65_536)))
+}
+
+pub fn decode_later_events_unreachable_under_default_cap_test() {
+  // Pre-#96 the entire stream failed when an early event was over the
+  // hardcoded cap. Document that behaviour: under the default cap the
+  // later events are still unreachable. The fix is to raise the cap
+  // (see the test below), not to silently skip the offender.
+  let oversize = string.repeat("x", 100_000)
+  let wire =
+    ssevents.encode_items([
+      ssevents.new(oversize) |> ssevents.event_item,
+      ssevents.new("late") |> ssevents.event_item,
+    ])
+  ssevents.decode(wire) |> should.equal(Error(EventTooLarge(65_536)))
+}
+
+pub fn decode_later_events_reachable_with_raised_cap_test() {
+  // Same wire as above, but with a raised cap — both events survive,
+  // including every later one that the pre-#96 hardcoded reject would
+  // have swallowed. (Strip the `\n` separators the chunking encoder
+  // inserts into long `data:` payloads, per #88.)
+  let oversize = string.repeat("x", 100_000)
+  let wire =
+    ssevents.encode_items([
+      ssevents.new(oversize) |> ssevents.event_item,
+      ssevents.new("late") |> ssevents.event_item,
+    ])
+  let lim = ssevents.default_limits() |> ssevents.with_max_event_size(200_000)
+  let assert Ok(items) = ssevents.decode_with_limits(wire, limits: lim)
+  let datas =
+    items
+    |> list.filter_map(fn(item) {
+      case ssevents.event_of_item(item) {
+        Some(ev) ->
+          Ok(ev |> ssevents.data_of |> string.replace(each: "\n", with: ""))
+        _ -> Error(Nil)
+      }
+    })
+  datas |> should.equal([oversize, "late"])
+}
+
+// === Existing-behaviour regression — small events unaffected ===
+
+pub fn decode_normal_event_test() {
+  let assert Ok([item]) = ssevents.decode("data: hello\n\n")
+  let assert Some(ev) = ssevents.event_of_item(item)
+  ssevents.data_of(ev) |> should.equal("hello")
+}
+
+// === Setter / getter wiring ===
+
+pub fn default_limits_max_event_size_is_65536_test() {
+  ssevents.default_limits()
+  |> ssevents.max_event_size
+  |> should.equal(65_536)
+}
+
+pub fn with_max_event_size_updates_the_cap_test() {
+  ssevents.default_limits()
+  |> ssevents.with_max_event_size(200_000)
+  |> ssevents.max_event_size
+  |> should.equal(200_000)
+}
+
+pub fn max_event_size_matches_max_event_bytes_test() {
+  // The two getters are aliases; raising one moves the other.
+  let lim = ssevents.default_limits() |> ssevents.with_max_event_size(123_456)
+  lim |> ssevents.max_event_size |> should.equal(123_456)
+  lim |> ssevents.max_event_bytes |> should.equal(123_456)
+}


### PR DESCRIPTION
## Summary

`ssevents.decode/1` rejected any event over 65_536 bytes with a hardcoded `Error(EventTooLarge(65_536))`, even though `encode_item` happily produces events of any size. A 100 KB event the package's own encoder emitted was unreachable on the decode side and could knock out every later event in the same wire.

This change adds `with_max_event_size/2` (and its `max_event_size/1` getter, an alias of `max_event_bytes/1`) on `ssevents/limit`, re-exported from the `ssevents` facade. `decode_with_limits` already plumbed `limit.max_event_bytes` through, so the new setter is all that's needed for callers to opt in to a larger per-event cap:

```gleam
let limits = ssevents.default_limits() |> ssevents.with_max_event_size(200_000)
ssevents.decode_with_limits(wire, limits: limits)
```

The default `decode/1` keeps the 65_536-byte ceiling as a memory-bound safety net for untrusted input — the override is opt-in, mirroring the `with_strict_retry_cap` pattern from #95. The `decode/1` and `decode_bytes/1` docstrings now explicitly call out the cap and the escape hatch.

## Changes

- `src/ssevents/limit.gleam`: add `with_max_event_size/2` (panics on `bytes < 1`) and `max_event_size/1` alias.
- `src/ssevents.gleam`: re-export both.
- `src/ssevents/decoder.gleam`: doc-comment on `decode/1` and `decode_bytes/1` calls out the 65_536 default and the `decode_with_limits` + `with_max_event_size` escape hatch.
- `test/ssevents/regression_event_too_large_test.gleam`: 9 tests covering the #96 repro (100 KB round-trip with raised cap), BitArray counterpart, default-cap reject regression, multi-event wire reachability, setter/getter wiring, and the normal-event baseline.
- `CHANGELOG.md`: 1 line under `## [Unreleased] ### Added`.

## Test plan

- [x] `just all` green (192 tests on both Erlang and JavaScript targets, glinter, format check, docs build, all 3 examples).
- [x] New regression test `decode_large_event_with_relaxed_limit_test` reproduces the #96 scenario and confirms the fix.
- [x] New regression test `decode_default_limit_still_rejects_oversize_test` confirms the default `decode/1` behaviour is unchanged.
- [x] New regression test `decode_normal_event_test` confirms small events are unaffected.

Closes #96