### PR TITLE
chore(release): prepare v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-05-21
+
 ### Changed
 
 - **Breaking — `ssevents/decoder`**: `retry:` values whose integer form exceeds `limit.default_max_retry_value` (24 h in ms) no longer fail the whole stream with `Error(InvalidRetry(_))`. The decoder now silently drops the offending field to `None` and the surrounding event still dispatches — symmetric with the encoder's `retry_clamp/2` and matching WHATWG SSE's lenient parser thesis. A single hostile `retry: 99999999999999` can no longer knock out the rest of the stream. Callers that need to detect such overruns explicitly can opt back into the strict posture via `ssevents.with_strict_retry_cap(limits, True)`. (#95)

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "ssevents"
-version = "0.13.0"
+version = "0.14.0"
 description = "Server-Sent Events primitives for Gleam"
 licences = ["MIT"]
 repository = { type = "github", user = "nao1215", repo = "ssevents" }


### PR DESCRIPTION
### Changed

- **Breaking — `ssevents/decoder`**: `retry:` values whose integer form exceeds `limit.default_max_retry_value` (24 h in ms) no longer fail the whole stream with `Error(InvalidRetry(_))`. The decoder now silently drops the offending field to `None` and the surrounding event still dispatches — symmetric with the encoder's `retry_clamp/2` and matching WHATWG SSE's lenient parser thesis. A single hostile `retry: 99999999999999` can no longer knock out the rest of the stream. Callers that need to detect such overruns explicitly can opt back into the strict posture via `ssevents.with_strict_retry_cap(limits, True)`. (#95)

### Added

- **`ssevents` / `ssevents/limit`**: `with_strict_retry_cap/2` and `strict_retry_cap/1`. Opt back into the pre-0.14 strict posture where `retry:` values above `max_retry_value` fail the whole decode. The default stays lenient. (#95)
- **`ssevents` / `ssevents/limit`**: `with_max_event_size/2` and `max_event_size/1`. Raise the decoder's per-event byte cap so caller-trusted oversize events round-trip through `decode_with_limits` instead of failing the whole stream with `Error(EventTooLarge(65_536))`; the default `decode/1` keeps the 65_536-byte safety net. (#96)
